### PR TITLE
Cleanup details page, add utilities

### DIFF
--- a/starwarswiki/src/presenters/detailsPresenter.jsx
+++ b/starwarswiki/src/presenters/detailsPresenter.jsx
@@ -3,25 +3,6 @@ import DetailsView from '../views/detailsView';
 import { getDetails } from '../utilities';
 import Vortex from '../components/Vortex.jsx';
 
-const related = [
-	{
-		id: '64292927021f17e13fbc1efd',
-		name: 'Cliegg Lars',
-		image: 'https://lumiere-a.akamaihd.net/v1/images/databank_cliegglars_01_169_c2f0b9cb.jpeg',
-	},
-	{
-		id: '64292927021f17e13fbc1f01',
-		name: 'Clone Captain Howzer',
-		image: 'https://lumiere-a.akamaihd.net/v1/images/clone-captain-howzer-main_149c5805.jpeg',
-	},
-	{
-		id: '64292927021f17e13fbc1f09',
-		name: 'Clone Commander Jet',
-		image:
-			'https://lumiere-a.akamaihd.net/v1/images/databank_clonecommanderjet_01_169_e88dd6fb.jpeg',
-	},
-];
-
 export default observer(function Details(props) {
 	const recievedData = getDetails();
 
@@ -32,6 +13,6 @@ export default observer(function Details(props) {
 		const desc = recievedData.data[0].description;
 		const image = recievedData.data[0].image;
 
-		return <DetailsView details={desc} image={image} name={name} suggested={related}></DetailsView>;
+		return <DetailsView details={desc} image={image} name={name}></DetailsView>;
 	}
 });

--- a/starwarswiki/src/presenters/detailsPresenter.jsx
+++ b/starwarswiki/src/presenters/detailsPresenter.jsx
@@ -22,8 +22,6 @@ const related = [
 ];
 
 export default observer(function Details(props) {
-	function showDetailsACB(id) {}
-
 	const recievedData = getDetails();
 
 	if (recievedData.loading && !recievedData.error) return 'Loading...';
@@ -33,14 +31,6 @@ export default observer(function Details(props) {
 		const desc = recievedData.data[0].description;
 		const image = recievedData.data[0].image;
 
-		return (
-			<DetailsView
-				details={desc}
-				image={image}
-				name={name}
-				suggested={related}
-				showDetails={showDetailsACB}
-			></DetailsView>
-		);
+		return <DetailsView details={desc} image={image} name={name} suggested={related}></DetailsView>;
 	}
 });

--- a/starwarswiki/src/presenters/detailsPresenter.jsx
+++ b/starwarswiki/src/presenters/detailsPresenter.jsx
@@ -1,6 +1,6 @@
 import { observer } from 'mobx-react-lite';
 import DetailsView from '../views/detailsView';
-import { fetchSWDatabank } from '../fetch';
+import { getDetails } from '../utilities';
 
 const related = [
 	{
@@ -24,16 +24,7 @@ const related = [
 export default observer(function Details(props) {
 	function showDetailsACB(id) {}
 
-	let path = window.location.pathname;
-
-	function parseURL(path) {
-		const newPath = path.split('/');
-		return newPath;
-	}
-
-	let splitURL = parseURL(path);
-	let page = splitURL[splitURL.length - 2] + '/name/' + splitURL[splitURL.length - 1];
-	const recievedData = fetchSWDatabank(page, {}, splitURL[splitURL.length - 1]);
+	const recievedData = getDetails();
 
 	if (recievedData.loading && !recievedData.error) return 'Loading...';
 	else if (recievedData.error) return 'Error';

--- a/starwarswiki/src/presenters/detailsPresenter.jsx
+++ b/starwarswiki/src/presenters/detailsPresenter.jsx
@@ -1,6 +1,7 @@
 import { observer } from 'mobx-react-lite';
 import DetailsView from '../views/detailsView';
 import { getDetails } from '../utilities';
+import Vortex from '../components/Vortex.jsx';
 
 const related = [
 	{
@@ -24,7 +25,7 @@ const related = [
 export default observer(function Details(props) {
 	const recievedData = getDetails();
 
-	if (recievedData.loading && !recievedData.error) return 'Loading...';
+	if (recievedData.loading && !recievedData.error) return <Vortex />;
 	else if (recievedData.error) return 'Error';
 	else if (!recievedData.loading && !recievedData.error) {
 		const name = recievedData.data[0].name;

--- a/starwarswiki/src/utilities.js
+++ b/starwarswiki/src/utilities.js
@@ -1,0 +1,10 @@
+import { fetchSWDatabank } from './fetch';
+
+function getDetails() {
+	let path = window.location.pathname;
+	const splitURL = path.split('/');
+	let page = splitURL[splitURL.length - 2] + '/name/' + splitURL[splitURL.length - 1];
+	return fetchSWDatabank(page, {}, splitURL[splitURL.length - 1]);
+}
+
+export { getDetails };

--- a/starwarswiki/src/views/detailsView.jsx
+++ b/starwarswiki/src/views/detailsView.jsx
@@ -1,10 +1,3 @@
-import Card from '../components/Card';
-
-/*
-	'suggested' is an array of objects. The attributes of the objects are 'id', 'name'
-	and 'image'.
-*/
-
 function DetailsView(props) {
 	return (
 		<div>
@@ -12,20 +5,8 @@ function DetailsView(props) {
 			<img src={props.image}></img>
 			<h3>Description</h3>
 			<p>{props.details}</p>
-			<h3>You may also like</h3>
-			{props.suggested.map(getCardCB)}
 		</div>
 	);
-
-	function showDetailsACB(id) {
-		props.showDetails(id);
-	}
-
-	function getCardCB(object) {
-		return (
-			<Card key={object.id} image={object.image} name={object.name} onClick={showDetailsACB} />
-		);
-	}
 }
 
 export default DetailsView;


### PR DESCRIPTION
- Moved URL parsing and data fetching to utilities.js
- Removed unused functions
- Removed "you may also like" section from details view and presenter. It should be in a different view
- Added suspense when a page is loading

Test functionality by going to ```/characters``` and clicking any character. Suspense will show before fetch is complete and related cards will be gone.