### PR TITLE
Add MoreDetailsView

### DIFF
--- a/starwarswiki/src/App.jsx
+++ b/starwarswiki/src/App.jsx
@@ -8,6 +8,7 @@ import ErrorPresenter from './presenters/errorPresenter.jsx';
 import HeaderPresenter from './presenters/headerPresenter.jsx';
 import ProfilePresenter from './presenters/profilePresenter.jsx';
 import SearchPresenter from './presenters/searchPresenter.jsx';
+import MoreDetailsPresenter from './presenters/moreDetailsPresenter.jsx';
 
 function makeRouter(props) {
 	return createBrowserRouter([
@@ -76,6 +77,7 @@ function makeRouter(props) {
 				<>
 					<HeaderPresenter model={props.model} />
 					<DetailsPresenter model={props.model} />
+					<MoreDetailsPresenter model={props.model} />
 				</>
 			),
 			errorElement: (
@@ -91,6 +93,7 @@ function makeRouter(props) {
 				<>
 					<HeaderPresenter model={props.model} />
 					<DetailsPresenter model={props.model} />
+					<MoreDetailsPresenter model={props.model} />
 				</>
 			),
 			errorElement: (
@@ -106,6 +109,7 @@ function makeRouter(props) {
 				<>
 					<HeaderPresenter model={props.model} />
 					<DetailsPresenter model={props.model} />
+					<MoreDetailsPresenter model={props.model} />
 				</>
 			),
 			errorElement: (

--- a/starwarswiki/src/models/firebaseModel.js
+++ b/starwarswiki/src/models/firebaseModel.js
@@ -59,3 +59,9 @@ function readFromDB(uid) {
 		reactiveModel.setFavsFromDB(favoritesFromDB);
 	});
 }
+
+export function readHash(location) {
+	get(ref(db, '/apiHash/' + location)).then((snapshot) =>
+		reactiveModel.setCurrentHash(snapshot.val(), location),
+	);
+}

--- a/starwarswiki/src/models/model.js
+++ b/starwarswiki/src/models/model.js
@@ -1,4 +1,4 @@
-import { fetchSWDatabank } from '../fetch.js';
+import { fetchSWDatabank, fetchSWAPI } from '../fetch.js';
 import { queryClient } from '../main.jsx';
 import { writeToDB } from './firebaseModel.js';
 
@@ -12,6 +12,8 @@ export default {
 
 	currentDetails: undefined,
 	details: {},
+	currentMoreDetails: undefined,
+	moreDetails: {},
 
 	setLoading(state) {
 		this.isLoading = state;
@@ -52,6 +54,12 @@ export default {
 		await fetchSWDatabank(params, {}, params);
 		this.details = queryClient.getQueryData(params);
 		this.currentDetails = params;
+	},
+
+	async setMoreDetails(params) {
+		await fetchSWAPI(params, {}, params);
+		this.moreDetails = queryClient.getQueriesData(params);
+		this.currentMoreDetails = params;
 	},
 
 	unSetCurrentBrowse() {

--- a/starwarswiki/src/models/model.js
+++ b/starwarswiki/src/models/model.js
@@ -14,7 +14,6 @@ export default {
 	details: {},
 	currentMoreDetails: undefined,
 	moreDetails: {},
-	detailsLoaded: false,
 	currentHash: undefined,
 	hash: {},
 

--- a/starwarswiki/src/models/model.js
+++ b/starwarswiki/src/models/model.js
@@ -14,6 +14,9 @@ export default {
 	details: {},
 	currentMoreDetails: undefined,
 	moreDetails: {},
+	detailsLoaded: false,
+	currentHash: undefined,
+	hash: {},
 
 	setLoading(state) {
 		this.isLoading = state;
@@ -51,17 +54,20 @@ export default {
 	},
 
 	async setDetails(params) {
+		this.detailsLoaded = false;
 		await fetchSWDatabank(params, {}, params);
 		this.details = queryClient.getQueryData(params);
 		this.currentDetails = params;
 	},
 
 	async setMoreDetails(params) {
+		this.detailsLoaded = false;
 		if (params) {
 			await fetchSWAPI(params, {}, params);
 			this.moreDetails = queryClient.getQueriesData(params);
 			this.currentMoreDetails = params;
 		}
+		this.detailsLoaded = true;
 	},
 
 	unSetCurrentBrowse() {
@@ -73,6 +79,7 @@ export default {
 		this.browseResult = queryClient.getQueryData(params);
 		this.currentBrowse = params;
 	},
+
 	async addBrowseResult(params) {
 		await fetchSWDatabank(params, {}, params);
 		let data = [...this.browseResult.data, ...queryClient.getQueryData(params).data];
@@ -93,5 +100,10 @@ export default {
 			}),
 		);
 		this.searchReady = true;
+	},
+
+	setCurrentHash(hash, location) {
+		this.hash = hash;
+		this.currentHash = location;
 	},
 };

--- a/starwarswiki/src/models/model.js
+++ b/starwarswiki/src/models/model.js
@@ -57,9 +57,11 @@ export default {
 	},
 
 	async setMoreDetails(params) {
-		await fetchSWAPI(params, {}, params);
-		this.moreDetails = queryClient.getQueriesData(params);
-		this.currentMoreDetails = params;
+		if (params) {
+			await fetchSWAPI(params, {}, params);
+			this.moreDetails = queryClient.getQueriesData(params);
+			this.currentMoreDetails = params;
+		}
 	},
 
 	unSetCurrentBrowse() {

--- a/starwarswiki/src/presenters/detailsPresenter.jsx
+++ b/starwarswiki/src/presenters/detailsPresenter.jsx
@@ -1,6 +1,15 @@
 import { observer } from 'mobx-react-lite';
 import DetailsView from '../views/detailsView';
+import MoreDetailsView from '../views/moreDetailsView';
 import Vortex from '../components/Vortex.jsx';
+
+const data = {
+	swapiId: 'cGVvcGxlOjE=',
+	swapiName: 'Luke Skywalker',
+	swapiType: 'People',
+	swdName: 'Luke Skywalker',
+};
+let moreDetails = false;
 
 export default observer(function Details(props) {
 	function addFavoriteACB(object) {
@@ -15,23 +24,53 @@ export default observer(function Details(props) {
 	const splitURL = path.split('/');
 	let page = splitURL[splitURL.length - 2] + '/name/' + splitURL[splitURL.length - 1];
 
-	if (!props.model.details || props.model.currentDetails !== page) {
+	let moreDetailsPath = atob(data.swapiId).split(':');
+	let moreDetailsPage = `${moreDetailsPath[0]}/${moreDetailsPath[1]}`;
+
+	if (!props.model.details || props.model.currentDetails !== page || !props.model.moreDetails) {
 		props.model.setDetails(page);
+		props.model.setMoreDetails(moreDetailsPage);
 		return <Vortex />;
-	} else if (props.model.details === null) return 'Error';
+	} else if (props.model.details === null || props.model.moreDetails === null) return 'Error';
 	else {
+		moreDetails = props.model.moreDetails[0]?.[1];
+
+		if (moreDetails) {
+			moreDetails = Object.keys(moreDetails).map((key) => {
+				return {
+					key: key,
+					value: moreDetails[key],
+				};
+			});
+
+			moreDetails = moreDetails.filter(({ key, value }) => {
+				if (key === 'name' || key === 'created' || key === 'edited') return false;
+				if (typeof value === 'string' && value.startsWith('http')) return false;
+				if (Array.isArray(value)) return false;
+				return true;
+			});
+
+			moreDetails = moreDetails.map((item) => ({
+				key: item.key.replace('_', ' '),
+				value: item.value,
+			}));
+		}
+
 		return (
-			<DetailsView
-				loggedIn={props.model.user}
-				details={props.model.details[0].description}
-				image={props.model.details[0].image}
-				name={props.model.details[0].name}
-				id={props.model.details[0]._id}
-				path={splitURL[splitURL.length - 2]}
-				fav={props.model.favorites}
-				removeFavorite={removeFavoriteACB}
-				addFavorite={addFavoriteACB}
-			></DetailsView>
+			<>
+				<DetailsView
+					loggedIn={props.model.user}
+					details={props.model.details[0].description}
+					image={props.model.details[0].image}
+					name={props.model.details[0].name}
+					id={props.model.details[0]._id}
+					path={splitURL[splitURL.length - 2]}
+					fav={props.model.favorites}
+					removeFavorite={removeFavoriteACB}
+					addFavorite={addFavoriteACB}
+				/>
+				{moreDetails && <MoreDetailsView details={moreDetails} />}
+			</>
 		);
 	}
 });

--- a/starwarswiki/src/presenters/detailsPresenter.jsx
+++ b/starwarswiki/src/presenters/detailsPresenter.jsx
@@ -24,8 +24,12 @@ export default observer(function Details(props) {
 	const splitURL = path.split('/');
 	let page = splitURL[splitURL.length - 2] + '/name/' + splitURL[splitURL.length - 1];
 
-	let moreDetailsPath = atob(data.swapiId).split(':');
-	let moreDetailsPage = `${moreDetailsPath[0]}/${moreDetailsPath[1]}`;
+	let moreDetailsPage = undefined;
+
+	if (data) {
+		let moreDetailsPath = atob(data?.swapiId).split(':');
+		moreDetailsPage = `${moreDetailsPath[0]}/${moreDetailsPath[1]}`;
+	}
 
 	if (!props.model.details || props.model.currentDetails !== page || !props.model.moreDetails) {
 		props.model.setDetails(page);

--- a/starwarswiki/src/presenters/detailsPresenter.jsx
+++ b/starwarswiki/src/presenters/detailsPresenter.jsx
@@ -1,16 +1,6 @@
 import { observer } from 'mobx-react-lite';
 import DetailsView from '../views/detailsView';
-import MoreDetailsView from '../views/moreDetailsView';
 import Vortex from '../components/Vortex.jsx';
-import { readHash } from '../models/firebaseModel.js';
-
-const data = {
-	swapiId: 'cGVvcGxlOjE=',
-	swapiName: 'Luke Skywalker',
-	swapiType: 'People',
-	swdName: 'Luke Skywalker',
-};
-let moreDetails = false;
 
 export default observer(function Details(props) {
 	function addFavoriteACB(object) {
@@ -25,72 +15,23 @@ export default observer(function Details(props) {
 	const splitURL = path.split('/');
 	let page = splitURL[splitURL.length - 2] + '/name/' + splitURL[splitURL.length - 1];
 
-	if (!props.model.detailsLoaded || props.model.currentDetails !== page) {
-		if (!props.model.details || props.model.currentDetails !== page) {
-			props.model.setDetails(page);
-
-			if (props.model.currentHash !== splitURL[splitURL.length - 2]) {
-				console.log('hash');
-				readHash(splitURL[splitURL.length - 2]);
-			}
-		}
-
-		if (
-			props.model.details[0] &&
-			props.model.currentDetails === page &&
-			props.model.currentHash === splitURL[splitURL.length - 2]
-		) {
-			const hashedItem = props.model.hash[props.model.details?.[0]?._id];
-			if (hashedItem) {
-				const moreDetailsPath = atob(hashedItem.swapiId).split(':');
-				const moreDetailsPage = `${moreDetailsPath[0]}/${moreDetailsPath[1]}`;
-				props.model.setMoreDetails(moreDetailsPage);
-			} else {
-				props.model.setMoreDetails(undefined);
-			}
-		}
-
+	if (!props.model.details || props.model.currentDetails !== page) {
+		props.model.setDetails(page);
 		return <Vortex />;
-	} else if (props.model.details === null || props.model.moreDetails === null) return 'Error';
+	} else if (props.model.details === null) return 'Error';
 	else {
-		moreDetails = props.model.moreDetails[0]?.[1];
-
-		if (moreDetails) {
-			moreDetails = Object.keys(moreDetails).map((key) => {
-				return {
-					key: key,
-					value: moreDetails[key],
-				};
-			});
-
-			moreDetails = moreDetails.filter(({ key, value }) => {
-				if (key === 'name' || key === 'created' || key === 'edited') return false;
-				if (typeof value === 'string' && value.startsWith('http')) return false;
-				if (Array.isArray(value)) return false;
-				return true;
-			});
-
-			moreDetails = moreDetails.map((item) => ({
-				key: item.key.replaceAll('_', ' '),
-				value: item.value,
-			}));
-		}
-
 		return (
-			<>
-				<DetailsView
-					loggedIn={props.model.user}
-					details={props.model.details[0].description}
-					image={props.model.details[0].image}
-					name={props.model.details[0].name}
-					id={props.model.details[0]._id}
-					path={splitURL[splitURL.length - 2]}
-					fav={props.model.favorites}
-					removeFavorite={removeFavoriteACB}
-					addFavorite={addFavoriteACB}
-				/>
-				{moreDetails && <MoreDetailsView details={moreDetails} />}
-			</>
+			<DetailsView
+				loggedIn={props.model.user}
+				details={props.model.details[0].description}
+				image={props.model.details[0].image}
+				name={props.model.details[0].name}
+				id={props.model.details[0]._id}
+				path={splitURL[splitURL.length - 2]}
+				fav={props.model.favorites}
+				removeFavorite={removeFavoriteACB}
+				addFavorite={addFavoriteACB}
+			/>
 		);
 	}
 });

--- a/starwarswiki/src/presenters/moreDetailsPresenter.jsx
+++ b/starwarswiki/src/presenters/moreDetailsPresenter.jsx
@@ -52,8 +52,12 @@ export default observer(function MoreDetails(props) {
 			}));
 		}
 
-		return <>{moreDetails && <MoreDetailsView details={moreDetails} />}</>;
+		return <MoreDetailsView details={moreDetails} />;
 	} else {
-		return;
+		return (
+			<MoreDetailsView
+				details={[{ key: "'Your eyes can deceive you; don't trust them.'", value: '' }]}
+			/>
+		);
 	}
 });

--- a/starwarswiki/src/presenters/moreDetailsPresenter.jsx
+++ b/starwarswiki/src/presenters/moreDetailsPresenter.jsx
@@ -1,0 +1,59 @@
+import { observer } from 'mobx-react-lite';
+import MoreDetailsView from '../views/moreDetailsView';
+import { readHash } from '../models/firebaseModel.js';
+
+export default observer(function MoreDetails(props) {
+	const splitURL = window.location.pathname.split('/');
+	const page = splitURL[splitURL.length - 2] + '/name/' + splitURL[splitURL.length - 1];
+
+	if (props.model.currentHash !== splitURL[splitURL.length - 2]) {
+		readHash(splitURL[splitURL.length - 2]);
+	}
+
+	let moreDetailsPage;
+
+	if (props.model.details[0] && props.model.currentHash === splitURL[splitURL.length - 2]) {
+		const hashedItem = props.model.hash[props.model.details?.[0]?._id];
+
+		if (hashedItem) {
+			const moreDetailsPath = atob(hashedItem.swapiId).split(':');
+			moreDetailsPage = `${moreDetailsPath[0]}/${moreDetailsPath[1]}`;
+		}
+
+		if (props.model.currentMoreDetails !== moreDetailsPage) {
+			props.model.setMoreDetails(moreDetailsPage);
+		}
+	}
+
+	if (
+		props.model.moreDetails[0] !== undefined &&
+		props.model.currentMoreDetails === moreDetailsPage
+	) {
+		let moreDetails = props.model.moreDetails[0]?.[1];
+
+		if (moreDetails) {
+			moreDetails = Object.keys(moreDetails).map((key) => {
+				return {
+					key: key,
+					value: moreDetails[key],
+				};
+			});
+
+			moreDetails = moreDetails.filter(({ key, value }) => {
+				if (key === 'name' || key === 'created' || key === 'edited') return false;
+				if (typeof value === 'string' && value.startsWith('http')) return false;
+				if (Array.isArray(value)) return false;
+				return true;
+			});
+
+			moreDetails = moreDetails.map((item) => ({
+				key: item.key.replaceAll('_', ' '),
+				value: item.value,
+			}));
+		}
+
+		return <>{moreDetails && <MoreDetailsView details={moreDetails} />}</>;
+	} else {
+		return;
+	}
+});

--- a/starwarswiki/src/presenters/moreDetailsPresenter.jsx
+++ b/starwarswiki/src/presenters/moreDetailsPresenter.jsx
@@ -41,6 +41,7 @@ export default observer(function MoreDetails(props) {
 
 			moreDetails = moreDetails.filter(({ key, value }) => {
 				if (key === 'name' || key === 'created' || key === 'edited') return false;
+				if (value === 'unknown') return false;
 				if (typeof value === 'string' && value.startsWith('http')) return false;
 				if (Array.isArray(value)) return false;
 				return true;

--- a/starwarswiki/src/views/moreDetailsView.jsx
+++ b/starwarswiki/src/views/moreDetailsView.jsx
@@ -1,0 +1,17 @@
+function MoreDetailsView(props) {
+	return (
+		<div>
+			<h3>More Details</h3>
+			{props.details?.map((item) => {
+				return (
+					<div key={item.key}>
+						<h4>{item.key}</h4>
+						<p>{item.value}</p>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+export default MoreDetailsView;


### PR DESCRIPTION
Add an extra view to all details view that shows more data about the character/location/vehicle.
It gets the hashdata from Firebase and maps our two APIs together.

## Added

- MoreDetailsPresenter
- MoreDetailsView
- (Hashdata on Firebase)

## How to test

1. Go onto a page that has moreDetails, such as Luke, Yoda, Naboo, X-Wing
2. See if more details load at the bottom of the page
3. Go to another page that doesn't have more data.
4. Check if no data is shown.

## Todos

- Update the MoreDetailsView with better CSS.
- Show the key and values with the first letter capitalized.
- Make a layout for the details views that include the header, details and moreDetails to make it more DRY.