### PR TITLE
Show suspense while loading moreDetails

### DIFF
--- a/starwarswiki/src/presenters/moreDetailsPresenter.jsx
+++ b/starwarswiki/src/presenters/moreDetailsPresenter.jsx
@@ -1,16 +1,24 @@
 import { observer } from 'mobx-react-lite';
 import MoreDetailsView from '../views/moreDetailsView';
 import { readHash } from '../models/firebaseModel.js';
+import Vortex from '../components/Vortex.jsx';
+import { useLocation } from 'react-router-dom';
 
 export default observer(function MoreDetails(props) {
 	let loaded = false;
 	let moreDetails;
 
-	const splitURL = window.location.pathname.split('/');
-	const page = splitURL[splitURL.length - 2] + '/name/' + splitURL[splitURL.length - 1];
+	const splitURL = useLocation().pathname.split('/');
 
 	if (props.model.currentHash !== splitURL[splitURL.length - 2]) {
 		readHash(splitURL[splitURL.length - 2]);
+		console.log('Vortex 1');
+		return (
+			<div>
+				<h3>More Details</h3>
+				<Vortex />
+			</div>
+		);
 	}
 
 	let moreDetailsPage;
@@ -21,6 +29,8 @@ export default observer(function MoreDetails(props) {
 		if (hashedItem) {
 			const moreDetailsPath = atob(hashedItem.swapiId).split(':');
 			moreDetailsPage = `${moreDetailsPath[0]}/${moreDetailsPath[1]}`;
+		} else {
+			loaded = true;
 		}
 
 		if (props.model.currentMoreDetails !== moreDetailsPage) {
@@ -58,7 +68,15 @@ export default observer(function MoreDetails(props) {
 
 		loaded = true;
 	}
-	if (loaded) {
+	if (!loaded) {
+		console.log('Vortex 2');
+		return (
+			<div>
+				<h3>More Details</h3>
+				<Vortex />
+			</div>
+		);
+	} else if (loaded && moreDetails) {
 		return <MoreDetailsView details={moreDetails} />;
 	} else {
 		return (

--- a/starwarswiki/src/presenters/moreDetailsPresenter.jsx
+++ b/starwarswiki/src/presenters/moreDetailsPresenter.jsx
@@ -10,15 +10,17 @@ export default observer(function MoreDetails(props) {
 
 	const splitURL = useLocation().pathname.split('/');
 
+	const moreDetailsSpinner = (
+		<div>
+			<h3>More Details</h3>
+			<Vortex />
+		</div>
+	);
+
 	if (props.model.currentHash !== splitURL[splitURL.length - 2]) {
 		readHash(splitURL[splitURL.length - 2]);
 		console.log('Vortex 1');
-		return (
-			<div>
-				<h3>More Details</h3>
-				<Vortex />
-			</div>
-		);
+		return moreDetailsSpinner;
 	}
 
 	let moreDetailsPage;
@@ -70,12 +72,7 @@ export default observer(function MoreDetails(props) {
 	}
 	if (!loaded) {
 		console.log('Vortex 2');
-		return (
-			<div>
-				<h3>More Details</h3>
-				<Vortex />
-			</div>
-		);
+		return moreDetailsSpinner;
 	} else if (loaded && moreDetails) {
 		return <MoreDetailsView details={moreDetails} />;
 	} else {

--- a/starwarswiki/src/presenters/moreDetailsPresenter.jsx
+++ b/starwarswiki/src/presenters/moreDetailsPresenter.jsx
@@ -19,7 +19,6 @@ export default observer(function MoreDetails(props) {
 
 	if (props.model.currentHash !== splitURL[splitURL.length - 2]) {
 		readHash(splitURL[splitURL.length - 2]);
-		console.log('Vortex 1');
 		return moreDetailsSpinner;
 	}
 
@@ -71,7 +70,6 @@ export default observer(function MoreDetails(props) {
 		loaded = true;
 	}
 	if (!loaded) {
-		console.log('Vortex 2');
 		return moreDetailsSpinner;
 	} else if (loaded && moreDetails) {
 		return <MoreDetailsView details={moreDetails} />;

--- a/starwarswiki/src/presenters/moreDetailsPresenter.jsx
+++ b/starwarswiki/src/presenters/moreDetailsPresenter.jsx
@@ -14,9 +14,15 @@ export default observer(function MoreDetails(props) {
 		</div>
 	);
 
+	if (
+		props.model.currentDetails !==
+		splitURL[splitURL.length - 2] + '/name/' + splitURL[splitURL.length - 1]
+	) {
+		return moreDetailsSpinner;
+	}
+
 	if (props.model.currentHash !== splitURL[splitURL.length - 2]) {
 		readHash(splitURL[splitURL.length - 2]);
-		return moreDetailsSpinner;
 	}
 
 	let loaded = false;

--- a/starwarswiki/src/presenters/moreDetailsPresenter.jsx
+++ b/starwarswiki/src/presenters/moreDetailsPresenter.jsx
@@ -5,9 +5,6 @@ import Vortex from '../components/Vortex.jsx';
 import { useLocation } from 'react-router-dom';
 
 export default observer(function MoreDetails(props) {
-	let loaded = false;
-	let moreDetails;
-
 	const splitURL = useLocation().pathname.split('/');
 
 	const moreDetailsSpinner = (
@@ -22,6 +19,8 @@ export default observer(function MoreDetails(props) {
 		return moreDetailsSpinner;
 	}
 
+	let loaded = false;
+	let moreDetails;
 	let moreDetailsPage;
 
 	if (props.model.details[0] && props.model.currentHash === splitURL[splitURL.length - 2]) {

--- a/starwarswiki/src/presenters/moreDetailsPresenter.jsx
+++ b/starwarswiki/src/presenters/moreDetailsPresenter.jsx
@@ -3,6 +3,9 @@ import MoreDetailsView from '../views/moreDetailsView';
 import { readHash } from '../models/firebaseModel.js';
 
 export default observer(function MoreDetails(props) {
+	let loaded = false;
+	let moreDetails;
+
 	const splitURL = window.location.pathname.split('/');
 	const page = splitURL[splitURL.length - 2] + '/name/' + splitURL[splitURL.length - 1];
 
@@ -29,7 +32,7 @@ export default observer(function MoreDetails(props) {
 		props.model.moreDetails[0] !== undefined &&
 		props.model.currentMoreDetails === moreDetailsPage
 	) {
-		let moreDetails = props.model.moreDetails[0]?.[1];
+		moreDetails = props.model.moreDetails[0]?.[1];
 
 		if (moreDetails) {
 			moreDetails = Object.keys(moreDetails).map((key) => {
@@ -53,6 +56,9 @@ export default observer(function MoreDetails(props) {
 			}));
 		}
 
+		loaded = true;
+	}
+	if (loaded) {
 		return <MoreDetailsView details={moreDetails} />;
 	} else {
 		return (


### PR DESCRIPTION
Closes #53

###  Changes
- Fixed suspense while loading moreDetails from SWAPI
- Fixed moreDetailsView not updating fast enough

### Testing
Go to any character with more details, e.g. `Anakin Skywalker`. Then go to another with more details in a different category, e.g. `X-wing Starfighter`. Suspense should show and details should update accordingly, without Anakin's details showing initially like they did before. Now go to `4-LOM` who doesn't have more details. Suspense should show before 'Your eyes can deceive you; don't trust them.' shows. Everything should work from either search bar or browse.