### PR TITLE
Catch axios error, reformat

### DIFF
--- a/starwarswiki/src/fetch.js
+++ b/starwarswiki/src/fetch.js
@@ -1,30 +1,30 @@
 import axios from 'axios';
 import { useQueries } from 'react-query';
-import { queryClient } from "./main.jsx"
+import { queryClient } from './main.jsx';
 
 async function fetchApi(url, path, params, key) {
-	return queryClient.getQueryData(key) ?? await queryClient.fetchQuery({
-		concurrentQueriesLimit: 5,
-		staleTime: 86400000,
-		queryKey: key,
-		queryFn: () =>
-			axios.get(`${url}${path}?${new URLSearchParams(params)}`).then((res) => res.data),
-	})
+	return (
+		queryClient.getQueryData(key) ??
+		(await queryClient.fetchQuery({
+			concurrentQueriesLimit: 5,
+			staleTime: 86400000,
+			queryKey: key,
+			queryFn: () =>
+				axios
+					.get(`${url}${path}?${new URLSearchParams(params)}`)
+					.then((res) => res.data)
+					.catch((err) => console.log(err.message)),
+		}))
+	);
 }
 
 export async function fetchSWAPI(path, params, key) {
 	await fetchApi('https://swapi.dev/api/', path, params, key);
-
 }
 
 export async function fetchSWDatabank(path, params, key) {
 	//let { isLoading, isError, data } =
-	await fetchApi(
-		'https://starwars-databank-server.vercel.app/api/v1/',
-		path,
-		params,
-		key,
-	);
+	await fetchApi('https://starwars-databank-server.vercel.app/api/v1/', path, params, key);
 
 	if (queryClient.getQueryState(key).data === "These aren't the droids you're looking for...") {
 		queryClient.setQueryData(key, null);


### PR DESCRIPTION
Add catch when fetching data from the APIs. An error occurred when refreshing the browse views several times. An error was thrown that said that the 'Request aborted'. The error was not breaking the site, but now we have some handling of the error.

- Added catch in `fetchApi` in `fetch.js`
- Reformatted `fetch.js`