### PR TITLE
Remove more details header

### DIFF
--- a/starwarswiki/src/presenters/moreDetailsPresenter.jsx
+++ b/starwarswiki/src/presenters/moreDetailsPresenter.jsx
@@ -9,7 +9,6 @@ export default observer(function MoreDetails(props) {
 
 	const moreDetailsSpinner = (
 		<div>
-			<h3>More Details</h3>
 			<Vortex />
 		</div>
 	);


### PR DESCRIPTION
Fixes #78 

Removed 'More Details' header. Kept it in a `<div>` to render it below the detail's spinner.