### PR TITLE
Fix favorite limit in searchView

### DIFF
--- a/starwarswiki/src/presenters/searchPresenter.jsx
+++ b/starwarswiki/src/presenters/searchPresenter.jsx
@@ -20,6 +20,7 @@ export default observer(function SearchPresenter(props) {
 					doAdd={doAddACB}
 					doRemove={doRemoveACB}
 					fav={props.model.favorites}
+					maxFavorites={props.model.maxFavorites}
 					auth={props.model.user}
 				/>
 			);


### PR DESCRIPTION
Closes #82 

### Changes
Previously, the favorite limit was not passed to `browseView` from the `searchPresenter`. Thus, it was possible to exceed the favorite limit. I added one line to fix this.

### Testing
Test by going to the search view and try to add favorites when you have reached the limit. Toast should show saying that the limit is reached.