### PR TITLE
Main styling

### DIFF
--- a/starwarswiki/src/AnimatedRoutes.jsx
+++ b/starwarswiki/src/AnimatedRoutes.jsx
@@ -35,40 +35,42 @@ export default function AnimatedRoutes(props) {
 	return (
 		<>
 			<HeaderPresenter model={props.model} />
-			<AnimatePresence mode='wait'>
-				<Routes location={location} key={location.key}>
-					<Route index element={transition(<LandingPagePresenter model={props.model} />)} />
-					{searchPaths.map((path) => {
-						return (
-							<Route
-								key={path}
-								exact
-								path={path}
-								element={transition(<SearchPresenter model={props.model} />)}
-							/>
-						);
-					})}
-					{browsePaths.map((path) => {
-						return (
-							<Route
-								key={path}
-								exact
-								path={path}
-								element={transition(<BrowsePresenter model={props.model} />)}
-							/>
-						);
-					})}
-					{detailsPaths.map((path) => {
-						return <Route key={path} exact path={path} element={transition(detailsLayout)} />;
-					})}
-					<Route
-						exact
-						path='/profile'
-						element={transition(<ProfilePresenter model={props.model} />)}
-					/>
-					<Route exact path='*' element={transition(<ErrorPresenter />)} />
-				</Routes>
-			</AnimatePresence>
+			<main id='main'>
+				<AnimatePresence mode='wait'>
+					<Routes location={location} key={location.key}>
+						<Route index element={transition(<LandingPagePresenter model={props.model} />)} />
+						{searchPaths.map((path) => {
+							return (
+								<Route
+									key={path}
+									exact
+									path={path}
+									element={transition(<SearchPresenter model={props.model} />)}
+								/>
+							);
+						})}
+						{browsePaths.map((path) => {
+							return (
+								<Route
+									key={path}
+									exact
+									path={path}
+									element={transition(<BrowsePresenter model={props.model} />)}
+								/>
+							);
+						})}
+						{detailsPaths.map((path) => {
+							return <Route key={path} exact path={path} element={transition(detailsLayout)} />;
+						})}
+						<Route
+							exact
+							path='/profile'
+							element={transition(<ProfilePresenter model={props.model} />)}
+						/>
+						<Route exact path='*' element={transition(<ErrorPresenter />)} />
+					</Routes>
+				</AnimatePresence>
+			</main>
 		</>
 	);
 }

--- a/starwarswiki/src/App.jsx
+++ b/starwarswiki/src/App.jsx
@@ -4,6 +4,13 @@ import FooterPresenter from './presenters/footerPresenter.jsx';
 import AnimatedRoutes from './AnimatedRoutes.jsx';
 
 export default observer(function ReactRoot(props) {
+	window.onresize = function () {
+		const main = document.getElementById('main');
+		if (main) {
+			main.style.marginTop = `${document.getElementById('header')?.offsetHeight}px`;
+		}
+	};
+
 	return (
 		<>
 			<BrowserRouter>

--- a/starwarswiki/src/App.jsx
+++ b/starwarswiki/src/App.jsx
@@ -4,12 +4,15 @@ import FooterPresenter from './presenters/footerPresenter.jsx';
 import AnimatedRoutes from './AnimatedRoutes.jsx';
 
 export default observer(function ReactRoot(props) {
-	window.onresize = function () {
+	window.onload = updateMainTopMargin;
+	window.onresize = updateMainTopMargin;
+
+	function updateMainTopMargin() {
 		const main = document.getElementById('main');
 		if (main) {
 			main.style.marginTop = `${document.getElementById('header')?.offsetHeight}px`;
 		}
-	};
+	}
 
 	return (
 		<>

--- a/starwarswiki/src/components/Vortex.jsx
+++ b/starwarswiki/src/components/Vortex.jsx
@@ -4,8 +4,6 @@ export default function () {
 	return (
 		<Vortex
 			visible={true}
-			height='360'
-			width='360'
 			ariaLabel='vortex-loading'
 			wrapperStyle={{}}
 			wrapperClass='vortex-wrapper'

--- a/starwarswiki/src/presenters/headerPresenter.jsx
+++ b/starwarswiki/src/presenters/headerPresenter.jsx
@@ -5,13 +5,6 @@ import NavbarView from '../views/navbarView';
 import { observer } from 'mobx-react-lite';
 
 export default observer(function HeaderPresenter(props) {
-	window.onresize = function () {
-		const main = document.getElementById('main');
-		if (main) {
-			main.style.marginTop = `${document.getElementById('header')?.offsetHeight}px`;
-		}
-	};
-
 	const navigate = useNavigate();
 
 	function handleSearchSelect(item) {

--- a/starwarswiki/src/presenters/headerPresenter.jsx
+++ b/starwarswiki/src/presenters/headerPresenter.jsx
@@ -5,6 +5,13 @@ import NavbarView from '../views/navbarView';
 import { observer } from 'mobx-react-lite';
 
 export default observer(function HeaderPresenter(props) {
+	window.onresize = function () {
+		const main = document.getElementById('main');
+		if (main) {
+			main.style.marginTop = `${document.getElementById('header')?.offsetHeight}px`;
+		}
+	};
+
 	const navigate = useNavigate();
 
 	function handleSearchSelect(item) {
@@ -29,7 +36,7 @@ export default observer(function HeaderPresenter(props) {
 	}
 
 	return (
-		<header>
+		<header id='header'>
 			<NavbarView onClickHandler={updateData} user={props.model.user} />
 			<SearchBarView
 				handleSearchSelect={handleSearchSelect}

--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -78,6 +78,8 @@ header {
 
 main {
 	margin-top: calc(1.5rem + 2 * $margin);
+	display: flex;
+	justify-content: center;
 }
 
 .browse-page {

--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -77,11 +77,10 @@ header {
 }
 
 main {
-	margin-top: calc(1.5rem + 2 * $margin);
+	margin: calc(1.5rem + 2 * $margin) auto auto auto;
 	display: flex;
 	justify-content: center;
 	max-width: 3000px;
-	margin: auto;
 }
 
 .browse-page {

--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -327,13 +327,4 @@ footer {
 			width: 50vw;
 		}
 	}
-
-	.details-container {
-		flex-direction: row;
-		flex-wrap: nowrap;
-
-		img {
-			width: 50vw;
-		}
-	}
 }

--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -40,22 +40,21 @@ header {
 	justify-content: center;
 	align-items: center;
 	flex-wrap: wrap;
+	gap: calc($margin / 2) $margin;
+	padding: $margin;
 
 	position: fixed;
-	width: 100%;
+	width: calc(100vw - 2 * $margin);
 	z-index: 1;
 	top: 0;
 	left: 0;
-	padding-bottom: $margin;
-	background: linear-gradient(180deg, $black, rgba(0, 0, 0, 0.5) 70%, transparent);
+	background: linear-gradient(180deg, $black, rgba(0, 0, 0, 0.5) 80%, transparent);
 
 	nav {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: center;
 		gap: $margin;
-
-		padding: calc($margin / 2) $margin calc($margin / 2) 0;
 
 		a {
 			color: $yellow;
@@ -78,7 +77,7 @@ header {
 }
 
 main {
-	margin-top: calc(1.5 * $margin);
+	margin-top: calc(1.5rem + 2 * $margin);
 }
 
 .browse-page {

--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -77,6 +77,10 @@ header {
 	}
 }
 
+main {
+	margin-top: calc(1.5 * $margin);
+}
+
 .browse-page {
 	> * {
 		width: 400px;
@@ -134,7 +138,6 @@ header {
 }
 
 .cards-container {
-	margin: $margin 0 $margin 0;
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -85,7 +85,7 @@ main {
 
 .browse-page {
 	> * {
-		width: 400px;
+		width: min(100%, 400px);
 
 		img {
 			height: 200px;

--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -80,6 +80,8 @@ main {
 	margin-top: calc(1.5rem + 2 * $margin);
 	display: flex;
 	justify-content: center;
+	max-width: 3000px;
+	margin: auto;
 }
 
 .browse-page {
@@ -319,7 +321,7 @@ footer {
 	.landing-page {
 		flex-wrap: wrap;
 		> * {
-			width: clamp(320px, 30vw, 1200px);
+			width: clamp(320px, 32%, 1200px);
 		}
 	}
 

--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -83,6 +83,11 @@ main {
 	max-width: 3000px;
 }
 
+.vortex-wrapper {
+	height: 320px;
+	width: min(320px, 100%);
+}
+
 .browse-page {
 	> * {
 		width: min(100%, 400px);


### PR DESCRIPTION
### Changes
- Added a `<main>` tag around the main content to style all main content the same.
- Main content should no longer be shown behind the header from the start.
- Fix `margin-top` for the `<main>` to be changed by some code on window resize.

### What to test
- Check to resize your window to smaller widths where the header collapses and gets into 2 or more lines. The main should then jump down further.
- Check window sizes for larger than 3000px width. The main content should then be limited to not get any wider.