### PR TITLE
Toastify profile messages

### DIFF
--- a/starwarswiki/src/models/model.js
+++ b/starwarswiki/src/models/model.js
@@ -1,6 +1,6 @@
 import { fetchSWAPI, fetchSWDatabank } from '../fetch.js';
 import { queryClient, reactiveModel } from '../main.jsx';
-import { addFriendDB, friendRequest } from './firebaseModel.js'
+import { addFriendDB, friendRequest } from './firebaseModel.js';
 
 export default {
 	user: {},
@@ -123,8 +123,8 @@ export default {
 		if (string2) {
 			const second = await this.addBrowseResult(string2);
 			if (second.data && second.info) {
-				info = second.info
-				data = [...data, ...second.data]
+				info = second.info;
+				data = [...data, ...second.data];
 			}
 		}
 		let string3 = info?.next?.replace('/api/v1/', '');
@@ -185,11 +185,11 @@ export default {
 	},
 
 	addFriend(friendId) {
-		friendRequest(friendId)
+		friendRequest(friendId);
 	},
 
 	addRequest(friendId) {
-		this.sentRequests = [...this.sentRequests, friendId]
+		this.sentRequests = [...this.sentRequests, friendId];
 	},
 
 	setRequestsFromDb(requests) {
@@ -203,18 +203,15 @@ export default {
 		if (!friends) {
 			friends = [];
 		}
-		this.friends = Object.keys(friends)
+		this.friends = Object.keys(friends);
 	},
 
-	setCustomMessage(msg) {
-		this.customMessage = msg;
-	},
 	removeFriendRequest(uid) {
 		function findFriend(id) {
 			return id !== uid;
 		}
 
-		this.friendRequests = this.friendRequests.filter(findFriend)
+		this.friendRequests = this.friendRequests.filter(findFriend);
 	},
 
 	removeFriend(uid) {
@@ -222,7 +219,7 @@ export default {
 			return id !== uid;
 		}
 
-		this.friends = this.friends.filter(findFriend)
+		this.friends = this.friends.filter(findFriend);
 	},
 
 	removeSentRequest(uid) {
@@ -230,17 +227,17 @@ export default {
 			return id !== uid;
 		}
 
-		this.sentRequests = this.sentRequests.filter(findFriend)
+		this.sentRequests = this.sentRequests.filter(findFriend);
 	},
 
 	acceptFriendRequest(userID) {
-		addFriendDB(userID)
-		this.removeFriendRequest(userID)
-		this.friends = [...this.friends, userID]
+		addFriendDB(userID);
+		this.removeFriendRequest(userID);
+		this.friends = [...this.friends, userID];
 	},
 	setFriendsFavFromDB(data, id) {
 		if (data === null) {
-			data = []
+			data = [];
 		}
 		this.friendFavorites[id] = data;
 	},
@@ -251,5 +248,4 @@ export default {
 		}
 		this.friendRequests = Object.keys(requests);
 	},
-
 };

--- a/starwarswiki/src/presenters/profilePresenter.jsx
+++ b/starwarswiki/src/presenters/profilePresenter.jsx
@@ -29,11 +29,11 @@ export default observer(function ProfilePresenter(props) {
 		if (event.key === 'Enter') {
 			await findUser(event.target.value);
 			if (event.target.value === props.model.user.uid) {
-				toast.info('That is your ID. Add a friend instead!');
+				toast.error('That is your ID. Add a friend instead!');
 			} else if (props.model.friends.find((element) => element === event.target.value)) {
-				toast.info(`You and ${props.model.users[event.target.value]} are already friends!`);
+				toast.error(`You and ${props.model.users[event.target.value]} are already friends!`);
 			} else if (props.model.sentRequests.find((element) => element === event.target.value))
-				toast.info(
+				toast.error(
 					`You have already sent a friend request to ${props.model.users[event.target.value]}!`,
 				);
 			else if (props.model.friendRequests.find((element) => element === event.target.value)) {

--- a/starwarswiki/src/presenters/profilePresenter.jsx
+++ b/starwarswiki/src/presenters/profilePresenter.jsx
@@ -66,16 +66,19 @@ export default observer(function ProfilePresenter(props) {
 	function cancelRequest(uid) {
 		props.model.removeSentRequest(uid);
 		removeFriendRequest(uid);
+		toast.success(`Cancelled friend request to ${props.model.users[uid]}.`);
 	}
 
 	function declineFriend(uid) {
 		props.model.removeFriendRequest(uid);
 		removeRequest(uid);
+		toast.success(`Declined friend request from ${props.model.users[uid]}.`);
 	}
 
 	function removeFriend(uid) {
 		props.model.removeFriend(uid);
 		removeFriendDB(uid);
+		toast.success(`Removed ${props.model.users[uid]} from friend list.`);
 	}
 
 	function checkNames(id) {

--- a/starwarswiki/src/presenters/profilePresenter.jsx
+++ b/starwarswiki/src/presenters/profilePresenter.jsx
@@ -141,9 +141,9 @@ export default observer(function ProfilePresenter(props) {
 		} else
 			return (
 				<>
-					{defaultRender()}
 					{props.model.loadingFavs !== undefined && props.model.user.displayName ? (
 						<>
+							{defaultRender()}
 							<ProfileView user={props.model.user} inAnimation={props.model.inAnimation} />
 							{props.model.favorites.length ? (
 								<BrowseView

--- a/starwarswiki/src/presenters/profilePresenter.jsx
+++ b/starwarswiki/src/presenters/profilePresenter.jsx
@@ -37,7 +37,9 @@ export default observer(function ProfilePresenter(props) {
 					`You have already sent a friend request to ${props.model.users[event.target.value]}!`,
 				);
 			else if (props.model.friendRequests.find((element) => element === event.target.value)) {
-				//props.model.setCustomMessage('Add Friend by Accepting their Friend Request');
+				// you have a friend request from that user already
+				acceptFriend(event.target.value);
+				toast.success(`Added ${props.model.users[event.target.value]} to your friends!`);
 			} else if (props.model.isUser) {
 				props.model.addFriend(event.target.value);
 				props.model.addRequest(event.target.value);

--- a/starwarswiki/src/presenters/profilePresenter.jsx
+++ b/starwarswiki/src/presenters/profilePresenter.jsx
@@ -179,7 +179,6 @@ export default observer(function ProfilePresenter(props) {
 						hideID={hideID}
 						shouldShowId={props.model.showId}
 						yourID={props.model.user.uid}
-						customMessage={props.model.customMessage}
 						friendRequest={props.model.friendRequests}
 						acceptFriend={acceptFriend}
 						declineFriend={declineFriend}

--- a/starwarswiki/src/presenters/profilePresenter.jsx
+++ b/starwarswiki/src/presenters/profilePresenter.jsx
@@ -13,6 +13,8 @@ import Vortex from '../components/Vortex.jsx';
 import NoPermissionView from '../views/noPermissionView.jsx';
 import ErrorView from '../views/errorView.jsx';
 import { useEffect } from 'react';
+import Toastify from '../components/Toastify.jsx';
+import { toast } from 'react-toastify';
 
 export default observer(function ProfilePresenter(props) {
 	function doAddACB(card) {
@@ -24,23 +26,24 @@ export default observer(function ProfilePresenter(props) {
 	}
 
 	async function addFriend(event) {
-		props.model.setCustomMessage(undefined);
 		if (event.key === 'Enter') {
 			await findUser(event.target.value);
-			if (event.target.value === props.model.user.uid)
-				props.model.setCustomMessage('That is your ID!');
-			else if (props.model.friends.find((element) => element === event.target.value))
-				props.model.setCustomMessage('You are Friends!');
-			else if (props.model.sentRequests.find((element) => element === event.target.value))
-				props.model.setCustomMessage('Wait for your friend to respond');
-			else if (props.model.friendRequests.find((element) => element === event.target.value))
-				props.model.setCustomMessage('Add Friend by Accepting their Friend Request');
-			else if (props.model.isUser) {
+			if (event.target.value === props.model.user.uid) {
+				toast.info('That is your ID. Add a friend instead!');
+			} else if (props.model.friends.find((element) => element === event.target.value)) {
+				toast.info(`You and ${props.model.users[event.target.value]} are already friends!`);
+			} else if (props.model.sentRequests.find((element) => element === event.target.value))
+				toast.info(
+					`You have already sent a friend request to ${props.model.users[event.target.value]}!`,
+				);
+			else if (props.model.friendRequests.find((element) => element === event.target.value)) {
+				//props.model.setCustomMessage('Add Friend by Accepting their Friend Request');
+			} else if (props.model.isUser) {
 				props.model.addFriend(event.target.value);
 				props.model.addRequest(event.target.value);
-				props.model.setCustomMessage('Friend Request Sent!');
+				toast.success(`Friend request sent to ${props.model.users[event.target.value]}.`);
 			} else {
-				props.model.setCustomMessage('Wrong ID!');
+				toast.error('There are no users with that ID, try again!');
 			}
 		}
 	}
@@ -114,6 +117,7 @@ export default observer(function ProfilePresenter(props) {
 						) : (
 							props.model.users[site] + ' does not have any favorites yet...'
 						)}
+						<Toastify />
 					</>
 				);
 			} else if (

--- a/starwarswiki/src/presenters/profilePresenter.jsx
+++ b/starwarswiki/src/presenters/profilePresenter.jsx
@@ -39,7 +39,6 @@ export default observer(function ProfilePresenter(props) {
 			else if (props.model.friendRequests.find((element) => element === event.target.value)) {
 				// you have a friend request from that user already
 				acceptFriend(event.target.value);
-				toast.success(`Added ${props.model.users[event.target.value]} to your friends!`);
 			} else if (props.model.isUser) {
 				props.model.addFriend(event.target.value);
 				props.model.addRequest(event.target.value);
@@ -61,6 +60,7 @@ export default observer(function ProfilePresenter(props) {
 	function acceptFriend(uid) {
 		props.model.acceptFriendRequest(uid);
 		removeRequest(uid);
+		toast.success(`Added ${props.model.users[uid]} to your friends!`);
 	}
 
 	function cancelRequest(uid) {

--- a/starwarswiki/src/views/friendSidebarView.jsx
+++ b/starwarswiki/src/views/friendSidebarView.jsx
@@ -1,22 +1,35 @@
 import { Link } from 'react-router-dom';
+import Toastify from '../components/Toastify';
+import { toast } from 'react-toastify';
 
 export default function FriendSidebarView(props) {
 	return (
 		<>
-			<p>Add friend</p>
-			<input type={'text'} placeholder={`Enter your friend's ID`} onKeyUp={props.addfriend} />
-			<button onClick={props.shouldShowId === false ? props.showID : props.hideID}>
-				{props.shouldShowId === false ? 'Click to show your ID' : 'Click to hide your ID'}
-			</button>
-			{props.shouldShowId === true ? <p>props.yourID</p> : null}
-			{props.friendRequest.length ? <h3>Friend Requests</h3> : null}
-			{props.friendRequest.length ? <ul>{props.friendRequest.map(showFriends)}</ul> : null}
-			{props.sentRequests.length ? <h3>Pending Requests</h3> : null}
-			{props.sentRequests.length ? <ul>{props.sentRequests.map(showRequests)}</ul> : null}
-			{props.friends.length ? <h3>Your Friends</h3> : null}
-			{props.friends.length ? <ul>{props.friends.map(showAllCB)}</ul> : null}
+			<section>
+				<p>Add friend</p>
+				<input type={'text'} placeholder={`Enter your friend's ID`} onKeyUp={props.addfriend} />
+				<button onClick={showAndCopyID}>
+					{props.shouldShowId === false ? 'Click to show your ID' : 'Click to hide your ID'}
+				</button>
+				{props.shouldShowId === true ? <p>{props.yourID}</p> : null}
+				{props.friendRequest.length ? <h3>Friend Requests</h3> : null}
+				{props.friendRequest.length ? <ul>{props.friendRequest.map(showFriends)}</ul> : null}
+				{props.sentRequests.length ? <h3>Pending Requests</h3> : null}
+				{props.sentRequests.length ? <ul>{props.sentRequests.map(showRequests)}</ul> : null}
+				{props.friends.length ? <h3>Your Friends</h3> : null}
+				{props.friends.length ? <ul>{props.friends.map(showAllCB)}</ul> : null}
+			</section>
+			<Toastify />
 		</>
 	);
+
+	function showAndCopyID() {
+		props.shouldShowId === false ? props.showID() : props.hideID();
+		if (!props.shouldShowId) {
+			navigator.clipboard.writeText(props.yourID);
+			toast.info('Copied ID to clipboard!');
+		}
+	}
 
 	function showRequests(friend) {
 		function cancelFriend() {

--- a/starwarswiki/src/views/friendSidebarView.jsx
+++ b/starwarswiki/src/views/friendSidebarView.jsx
@@ -3,18 +3,18 @@ import { Link } from 'react-router-dom';
 export default function FriendSidebarView(props) {
 	return (
 		<>
+			<p>Add friend</p>
+			<input type={'text'} placeholder={`Enter your friend's ID`} onKeyUp={props.addfriend} />
 			<button onClick={props.shouldShowId === false ? props.showID : props.hideID}>
 				{props.shouldShowId === false ? 'Click to show your ID' : 'Click to hide your ID'}
 			</button>
 			{props.shouldShowId === true ? <p>props.yourID</p> : null}
 			{props.friendRequest.length ? <h3>Friend Requests</h3> : null}
-			{props.friendRequest.length ? props.friendRequest.map(showFriends) : null}
-			<p>Add friend</p>
-			<input type={'text'} placeholder={`Enter your friend's ID`} onKeyUp={props.addfriend} />
+			{props.friendRequest.length ? <ul>{props.friendRequest.map(showFriends)}</ul> : null}
 			{props.sentRequests.length ? <h3>Pending Requests</h3> : null}
-			{props.sentRequests.length ? props.sentRequests.map(showRequests) : null}
+			{props.sentRequests.length ? <ul>{props.sentRequests.map(showRequests)}</ul> : null}
 			{props.friends.length ? <h3>Your Friends</h3> : null}
-			<ul>{props.friends.length ? props.friends.map(showAllCB) : null}</ul>
+			{props.friends.length ? <ul>{props.friends.map(showAllCB)}</ul> : null}
 		</>
 	);
 
@@ -24,10 +24,10 @@ export default function FriendSidebarView(props) {
 		}
 
 		return (
-			<div key={friend}>
+			<li key={friend}>
 				{props.names[friend]}
 				<button onClick={cancelFriend}>Cancel</button>
-			</div>
+			</li>
 		);
 	}
 
@@ -41,11 +41,11 @@ export default function FriendSidebarView(props) {
 		}
 
 		return (
-			<div key={friend}>
+			<li key={friend}>
 				{props.names[friend]}
 				<button onClick={acceptFriend}>Accept</button>
 				<button onClick={declineFriend}>Decline</button>
-			</div>
+			</li>
 		);
 	}
 
@@ -55,7 +55,7 @@ export default function FriendSidebarView(props) {
 		}
 
 		return (
-			<div key={friend}>
+			<li key={friend}>
 				<Link to={'/profile/' + friend} key={friend}>
 					{props.names[friend]}
 				</Link>
@@ -66,7 +66,7 @@ export default function FriendSidebarView(props) {
 				) : (
 					<button onClick={removeFriend}>Remove Friend</button>
 				)}
-			</div>
+			</li>
 		);
 	}
 }

--- a/starwarswiki/src/views/friendSidebarView.jsx
+++ b/starwarswiki/src/views/friendSidebarView.jsx
@@ -1,68 +1,72 @@
-import { Link } from "react-router-dom";
+import { Link } from 'react-router-dom';
 
 export default function FriendSidebarView(props) {
 	return (
 		<>
-			<button
-				onClick={props.shouldShowId === false ? props.showID : props.hideID} >{props.shouldShowId === false ? "Click to show your ID" : "Click to hide your ID"}</button >
-			<p >{props.shouldShowId === true ? props.yourID : ""}</p >
-			<h3 >{props.friendRequest.length ? "Your Friend Requests" : ""}</h3 >
-			{props.friendRequest.length ? props.friendRequest.map(showFriends) : ""}
-			<p >Add friends with friend id:
-				<input type={"text"} placeholder={"Enter Your Friends ID"} onKeyUp={props.addfriend} />
-				{props.customMessage ? props.customMessage : ""}
-			</p >
-			<h3 >{props.sentRequests.length ? "Waiting for answer from:" : ""}</h3 >
-			{props.sentRequests.length ? props.sentRequests.map(showRequests) : ""}
-			<h3 >{props.friends.length ? "These are your Friends" : "Add friends to show them here!"}</h3 >
-			<>
-				{props.friends.length ? props.friends.map(showAllCB) : ""}
-			</>
+			<button onClick={props.shouldShowId === false ? props.showID : props.hideID}>
+				{props.shouldShowId === false ? 'Click to show your ID' : 'Click to hide your ID'}
+			</button>
+			{props.shouldShowId === true ? <p>props.yourID</p> : null}
+			{props.friendRequest.length ? <h3>Friend Requests</h3> : null}
+			{props.friendRequest.length ? props.friendRequest.map(showFriends) : null}
+			<p>Add friend</p>
+			<input type={'text'} placeholder={`Enter your friend's ID`} onKeyUp={props.addfriend} />
+			{props.sentRequests.length ? <h3>Pending Requests</h3> : null}
+			{props.sentRequests.length ? props.sentRequests.map(showRequests) : null}
+			{props.friends.length ? <h3>Your Friends</h3> : null}
+			<ul>{props.friends.length ? props.friends.map(showAllCB) : null}</ul>
 		</>
 	);
 
 	function showRequests(friend) {
 		function cancelFriend() {
-			props.cancelFriend(friend)
+			props.cancelFriend(friend);
 		}
 
-		return (<div key={friend} >
-			{props.names[friend]}
-			<button onClick={cancelFriend} >Cancel</button >
-		</div >)
+		return (
+			<div key={friend}>
+				{props.names[friend]}
+				<button onClick={cancelFriend}>Cancel</button>
+			</div>
+		);
 	}
 
 	function showFriends(friend) {
 		function acceptFriend() {
-			props.acceptFriend(friend)
+			props.acceptFriend(friend);
 		}
 
 		function declineFriend() {
-			props.declineFriend(friend)
-		}
-
-		return (<div key={friend} >
-			{props.names[friend]}
-			<button onClick={acceptFriend} >Accept</button >
-			<button onClick={declineFriend} >Decline</button >
-		</div >)
-	}
-
-	function showAllCB(friend) {
-
-		function removeFriend() {
-			props.removeFriend(friend)
+			props.declineFriend(friend);
 		}
 
 		return (
-			<div key={friend} >
-				<Link to={"/profile/" + friend} key={friend} >
+			<div key={friend}>
+				{props.names[friend]}
+				<button onClick={acceptFriend}>Accept</button>
+				<button onClick={declineFriend}>Decline</button>
+			</div>
+		);
+	}
+
+	function showAllCB(friend) {
+		function removeFriend() {
+			props.removeFriend(friend);
+		}
+
+		return (
+			<div key={friend}>
+				<Link to={'/profile/' + friend} key={friend}>
 					{props.names[friend]}
-				</Link >
-				{props.site === friend ? <Link to={"/profile"} >
-					<button onClick={removeFriend} >Remove Friend</button >
-				</Link > : <button onClick={removeFriend} >Remove Friend</button >}
-			</div >
-		)
+				</Link>
+				{props.site === friend ? (
+					<Link to={'/profile'}>
+						<button onClick={removeFriend}>Remove Friend</button>
+					</Link>
+				) : (
+					<button onClick={removeFriend}>Remove Friend</button>
+				)}
+			</div>
+		);
 	}
 }

--- a/starwarswiki/src/views/profileView.jsx
+++ b/starwarswiki/src/views/profileView.jsx
@@ -17,13 +17,13 @@ export default function ProfileView(props) {
 				<SignOutButton />
 				<h2>
 					{props.user.displayName === undefined
-						? 'Welcome to ' + props.user + "'s Profile"
-						: 'Hello There ' + props.user.displayName + '!'}
+						? 'Welcome to ' + props.user + "'s profile"
+						: 'Hello there, ' + props.user.displayName + '!'}
 				</h2>
 				<h3>
 					{props.user.displayName === undefined
-						? 'These are ' + props.user + "'s Favorites"
-						: 'These Are Your Favorites!'}
+						? props.user + "'s favorite pages"
+						: 'Your favorite pages'}
 				</h3>
 			</>
 		);


### PR DESCRIPTION
## Additions/changes
- Reformatted files
- Removed `setCustomMessage` function
- Added toasts instead of messages when adding friends
- Copy the ID to clipboard when clicking `Click to show your ID`. Added toast as feedback
- Changed behavior when adding a friend that has already sent you a friend request. Now you accept the incoming request instead
- Did some rewording in the messages and headers
- Changed tags in `friendSidebarView` for easier styling

## Testing
A unique toast should show for the following:
- Adding yourself to your friends
- Sending a friend request
- Sending a friend request multiple times to the same user
- Accepting a friend request
- Sending a friend request to a friend that has already sent you a request. Friend should also be added
- Adding a non-existing ID
- Adding a friend that is already on your friend list
- Clicking `Click to show your ID`

## Future improvements?
Are the following suggestions needed?
- Toast when a friend has accepted your request
- Toast when cancelling a request
- Toast when removing a friend
- Toast when declining a request