### PR TITLE
Main title and header styling

### DIFF
--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -150,6 +150,23 @@ main {
 	}
 }
 
+.main-title {
+	text-align: center;
+	margin-bottom: calc($margin / 2);
+
+	color: $black;
+	text-shadow: $yellow-stroke-ie;
+
+	h1 {
+		font-size: 3rem;
+		height: 3.2rem;
+	}
+
+	h2 {
+		font-size: 2rem;
+	}
+}
+
 .cards-container {
 	display: flex;
 	justify-content: center;
@@ -340,6 +357,13 @@ footer {
 	.landing-page {
 		> * {
 			width: clamp(320px, 32%, 1200px);
+		}
+	}
+
+	.main-title {
+		h1 {
+			font-size: 4rem;
+			height: 4.5rem;
 		}
 	}
 

--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -145,7 +145,7 @@ main {
 .landing-page {
 	> * {
 		p {
-			font-size: 3rem;
+			font-size: 2.5rem;
 		}
 	}
 }

--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -41,7 +41,7 @@ header {
 	align-items: center;
 	flex-wrap: wrap;
 	gap: calc($margin / 2) $margin;
-	padding: $margin;
+	padding: calc($margin / 2) $margin;
 
 	position: fixed;
 	width: calc(100% - 2 * $margin);
@@ -55,7 +55,7 @@ header {
 		flex-wrap: wrap;
 		justify-content: center;
 		align-items: center;
-		gap: $margin;
+		gap: calc($margin / 2) $margin;
 
 		a {
 			color: $yellow;

--- a/starwarswiki/src/views/landingPageView.jsx
+++ b/starwarswiki/src/views/landingPageView.jsx
@@ -2,8 +2,11 @@ import LandingCard from '../components/LandingCard';
 
 export default function LandingPageView(props) {
 	return (
-		<div>
-			<h1>STAR WARS WIKI</h1>
+		<>
+			<div className='main-title'>
+				<h1>STAR WARS</h1>
+				<h2>WIKI</h2>
+			</div>
 			<div className='cards-container landing-page'>
 				<LandingCard
 					text='CHARACTERS'
@@ -24,6 +27,6 @@ export default function LandingPageView(props) {
 					inAnimation={props.inAnimation}
 				/>
 			</div>
-		</div>
+		</>
 	);
 }


### PR DESCRIPTION
### Changes
- Added styling to the main title on the landing page, it should get smaller for small screen sizes (less than 800px).
- Halved the header & nav padding.
- Made landing page card text smaller.

Fixes #95 