### PR TITLE
Add alt text to all images

### DIFF
--- a/starwarswiki/src/components/Card.jsx
+++ b/starwarswiki/src/components/Card.jsx
@@ -22,7 +22,7 @@ export default function (card) {
 	return (
 		<div className='browse-card'>
 			<Link to={linkTo} replace={card.inAnimation ? true : false}>
-				<img src={card.image} />
+				<img src={card.image} alt={card.name}/>
 				<p>{card.name}</p>
 			</Link>
 			{card.auth ? (

--- a/starwarswiki/src/components/LandingCard.jsx
+++ b/starwarswiki/src/components/LandingCard.jsx
@@ -4,7 +4,7 @@ export default function LandingCard(props) {
 	return (
 		<div className='loading-card'>
 			<Link to={props.linkTo} replace={props.inAnimation ? true : false}>
-				<img src={props.image} />
+				<img src={props.image} alt={props.altText} />
 				<p>{props.text}</p>
 			</Link>
 		</div>

--- a/starwarswiki/src/views/detailsView.jsx
+++ b/starwarswiki/src/views/detailsView.jsx
@@ -22,7 +22,7 @@ function DetailsView(props) {
 
 	return (
 		<div className='details-container'>
-			<img src={props.image} />
+			<img src={props.image} alt={props.name} />
 			<div className='details'>
 				<div className='details-title'>
 					<h2>{props.name}</h2>

--- a/starwarswiki/src/views/landingPageView.jsx
+++ b/starwarswiki/src/views/landingPageView.jsx
@@ -8,18 +8,21 @@ export default function LandingPageView(props) {
 				<LandingCard
 					text='CHARACTERS'
 					image='https://lumiere-a.akamaihd.net/v1/images/Yoda-Retina_2a7ecc26.jpeg'
+					altText='Green Yoda in the swamp of Dagobah'
 					linkTo='/characters'
 					inAnimation={props.inAnimation}
 				/>
 				<LandingCard
 					text='VEHICLES'
 					image='https://lumiere-a.akamaihd.net/v1/images/millennium-falcon-main-tlj-a_7cf89d3a.jpeg'
+					altText='Millennium Falcon traveling in hyperspeed through space'
 					linkTo='/vehicles'
 					inAnimation={props.inAnimation}
 				/>
 				<LandingCard
 					text='LOCATIONS'
 					image='https://lumiere-a.akamaihd.net/v1/images/databank_mustafar_01_169_5b470758.jpeg'
+					altText='Dark mountainous and red lava filled volcanic landscape of the planet Mustafar'
 					linkTo='/locations'
 					inAnimation={props.inAnimation}
 				/>


### PR DESCRIPTION
### Changes
Added alt text that describes all images on the website. 
The browse/details only show the name of the character, since we can't generate better alt text for them. But the landing page has better alt text descriptions.

### How to test
Go onto the landing page, browse view and details view and inspect the images. They should now have the `alt` attribute inside of them with the correct text.