### PR TITLE
404 details

### DIFF
--- a/starwarswiki/src/presenters/detailsPresenter.jsx
+++ b/starwarswiki/src/presenters/detailsPresenter.jsx
@@ -2,6 +2,7 @@ import { observer } from 'mobx-react-lite';
 import DetailsView from '../views/detailsView';
 import Vortex from '../components/Vortex.jsx';
 import { useLocation } from 'react-router-dom';
+import ErrorView from '../views/errorView.jsx';
 
 export default observer(function Details(props) {
 	function addFavoriteACB(object) {
@@ -18,7 +19,7 @@ export default observer(function Details(props) {
 	if (!props.model.details || props.model.currentDetails !== page) {
 		props.model.setDetails(page);
 		return <Vortex />;
-	} else if (props.model.details === null) return 'Error';
+	} else if (props.model.details.length === 0) return <ErrorView />;
 	else {
 		return (
 			<DetailsView

--- a/starwarswiki/src/presenters/moreDetailsPresenter.jsx
+++ b/starwarswiki/src/presenters/moreDetailsPresenter.jsx
@@ -20,6 +20,8 @@ export default observer(function MoreDetails(props) {
 		return moreDetailsSpinner;
 	}
 
+	if (props.model.details.length === 0) return null;
+
 	if (props.model.currentHash !== splitURL[splitURL.length - 2]) {
 		readHash(splitURL[splitURL.length - 2]);
 	}


### PR DESCRIPTION
Fixes #104 

### Changes
Add 404 when going to an invalid details URL. This also fixes a bug in the hamburger.

### Test
Go to an invalid URL `/vehicles/Yoda`. 404 should show. Then go to `/characters/Yoda`. Should work as normal. Go to a character without more details, i.e `/characters/Admiral Ozzel`. More details should show quote as before.
