### PR TITLE
Scroll to top

### DIFF
--- a/starwarswiki/src/presenters/browsePresenter.jsx
+++ b/starwarswiki/src/presenters/browsePresenter.jsx
@@ -5,6 +5,10 @@ import { useLocation } from 'react-router-dom';
 import { useEffect } from 'react';
 
 export default observer(function Browse(props) {
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	}, []);
+
 	function doAddACB(card) {
 		props.model.addToFavorites(card);
 	}
@@ -16,7 +20,7 @@ export default observer(function Browse(props) {
 	async function handleScroll() {
 		const { scrollTop, clientHeight, scrollHeight } = document.documentElement;
 		if (scrollTop + clientHeight >= scrollHeight - clientHeight * 2) {
-			if (props.model.browseResult.info.next !== null) {
+			if (props.model.browseResult.info?.next !== null) {
 				await addData();
 			}
 		}

--- a/starwarswiki/src/presenters/browsePresenter.jsx
+++ b/starwarswiki/src/presenters/browsePresenter.jsx
@@ -20,7 +20,7 @@ export default observer(function Browse(props) {
 	async function handleScroll() {
 		const { scrollTop, clientHeight, scrollHeight } = document.documentElement;
 		if (scrollTop + clientHeight >= scrollHeight - clientHeight * 2) {
-			if (props.model.browseResult.info?.next !== null) {
+			if (props.model.browseResult?.info?.next !== null) {
 				await addData();
 			}
 		}

--- a/starwarswiki/src/presenters/detailsPresenter.jsx
+++ b/starwarswiki/src/presenters/detailsPresenter.jsx
@@ -3,8 +3,13 @@ import DetailsView from '../views/detailsView';
 import Vortex from '../components/Vortex.jsx';
 import { useLocation } from 'react-router-dom';
 import ErrorView from '../views/errorView.jsx';
+import { useEffect } from 'react';
 
 export default observer(function Details(props) {
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	}, []);
+
 	function addFavoriteACB(object) {
 		props.model.addToFavorites(object);
 	}

--- a/starwarswiki/src/presenters/landingPagePresenter.jsx
+++ b/starwarswiki/src/presenters/landingPagePresenter.jsx
@@ -1,6 +1,11 @@
 import LandingPageView from '../views/landingPageView';
 import { observer } from 'mobx-react-lite';
+import { useEffect } from 'react';
 
 export default observer(function LandingPagePresenter(props) {
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	}, []);
+
 	return <LandingPageView inAnimation={props.model.inAnimation} />;
 });

--- a/starwarswiki/src/presenters/profilePresenter.jsx
+++ b/starwarswiki/src/presenters/profilePresenter.jsx
@@ -17,6 +17,10 @@ import Toastify from '../components/Toastify.jsx';
 import { toast } from 'react-toastify';
 
 export default observer(function ProfilePresenter(props) {
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	}, []);
+
 	function doAddACB(card) {
 		props.model.addToFavorites(card);
 	}

--- a/starwarswiki/src/presenters/searchPresenter.jsx
+++ b/starwarswiki/src/presenters/searchPresenter.jsx
@@ -5,6 +5,10 @@ import HeaderPresenter from './headerPresenter';
 import { observer } from 'mobx-react-lite';
 
 export default observer(function SearchPresenter(props) {
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	}, []);
+
 	function doAddACB(card) {
 		props.model.addToFavorites(card);
 	}


### PR DESCRIPTION
### Tasks completed
- Some undefined checks in browse presenter
- Add useEffect with empty array as dependency that scroll to top. Meaning when the component is rendered for the first time, scroll to top.

### Testing
- Browse pages should always start at top (Characters, Vehicles, Locations, Search)
- Landing page should always start at top
- Profile page should always start at top
- Details page should always start at top