### PR TITLE
Change more details view

### DIFF
--- a/starwarswiki/src/presenters/moreDetailsPresenter.jsx
+++ b/starwarswiki/src/presenters/moreDetailsPresenter.jsx
@@ -83,7 +83,12 @@ export default observer(function MoreDetails(props) {
 	} else {
 		return (
 			<MoreDetailsView
-				details={[{ key: "'Your eyes can deceive you; don't trust them.'", value: '' }]}
+				details={[
+					{
+						key: "'Your eyes can deceive you; don't trust them.'",
+						value: 'No more details could be found.',
+					},
+				]}
 			/>
 		);
 	}

--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -373,6 +373,7 @@ main {
 	h4,
 	p {
 		text-transform: capitalize;
+		text-align: center;
 	}
 
 	p {


### PR DESCRIPTION
Fixes #109 

Added a line that “explains” the quote when no more details are found. This was needed after user complaints, thinking that the site was bugged, as the same quote showed everywhere.