### PR TITLE
Remove redundant alt text

### DIFF
--- a/starwarswiki/src/components/Card.jsx
+++ b/starwarswiki/src/components/Card.jsx
@@ -22,7 +22,7 @@ export default function (card) {
 	return (
 		<div className='browse-card'>
 			<Link to={linkTo} replace={card.inAnimation ? true : false}>
-				<img src={card.image} alt={card.name} />
+				<img src={card.image} />
 				<p>{card.name}</p>
 			</Link>
 			{card.auth ? (


### PR DESCRIPTION
Alt text was showing when loading cards, which was ugly and distracting. The alt text was the same as the card title, which made it redundant. Removed it as it made no difference for screen readers.