### PR TITLE
Improve Search

### DIFF
--- a/starwarswiki/src/presenters/detailsPresenter.jsx
+++ b/starwarswiki/src/presenters/detailsPresenter.jsx
@@ -8,6 +8,7 @@ import { useEffect } from 'react';
 export default observer(function Details(props) {
 	useEffect(() => {
 		window.scrollTo(0, 0);
+		props.model.setSearchString('');
 	}, []);
 
 	function addFavoriteACB(object) {

--- a/starwarswiki/src/presenters/headerPresenter.jsx
+++ b/starwarswiki/src/presenters/headerPresenter.jsx
@@ -4,16 +4,17 @@ import SearchBarView from '../views/searchBarView';
 import NavbarView from '../views/navbarView';
 import { observer } from 'mobx-react-lite';
 import HamburgerView from '../views/hamburgerView';
-import { useState } from 'react';
 
 export default observer(function HeaderPresenter(props) {
 	const navigate = useNavigate();
 
 	function updateData() {
+		props.model.setSearchString('');
 		props.model.unSetCurrentBrowse();
 	}
-	function handleOnClick(event) {
-		updateData(event.target.innerText.toLowerCase());
+
+	function handleOnClick() {
+		updateData();
 		props.model.setMenuOpen(!props.model.menuOpen);
 	}
 
@@ -26,6 +27,7 @@ export default observer(function HeaderPresenter(props) {
 	}
 
 	function handleSearchSelect(item) {
+		document.activeElement.blur();
 		let name = item.name.replaceAll('/', '%2F').replaceAll('.', '%2E');
 		props.model.unSetCurrentDetails();
 		navigate('/' + item.type + '/' + name);
@@ -33,6 +35,7 @@ export default observer(function HeaderPresenter(props) {
 
 	async function handleFormSubmit(event) {
 		event.preventDefault(); //Stop page from refreshing
+		document.activeElement.blur();
 		navigate('/search/' + props.model.searchString);
 		await props.model.setSearchResults();
 	}
@@ -58,6 +61,7 @@ export default observer(function HeaderPresenter(props) {
 				isOpen={props.model.menuOpen}
 			/>
 			<SearchBarView
+				searchString={props.model.searchString}
 				handleSearchSelect={handleSearchSelect}
 				handleFormSubmit={handleFormSubmit}
 				handleOnSearch={handleOnSearch}

--- a/starwarswiki/src/presenters/searchPresenter.jsx
+++ b/starwarswiki/src/presenters/searchPresenter.jsx
@@ -8,6 +8,7 @@ import { useEffect } from 'react';
 export default observer(function SearchPresenter(props) {
 	useEffect(() => {
 		window.scrollTo(0, 0);
+		props.model.setSearchString('');
 	}, []);
 
 	function doAddACB(card) {
@@ -33,7 +34,13 @@ export default observer(function SearchPresenter(props) {
 					path={location.pathname}
 				/>
 			);
-		else if (searchReady) return <h2>No results</h2>;
+		else if (searchReady)
+			return (
+				<>
+					<h2>No results</h2>
+					<h3>Please try again by typing in the search box</h3>
+				</>
+			);
 		else return <Vortex />;
 	}
 	return <>{render(props.model.searchReady)}</>;

--- a/starwarswiki/src/views/searchBarView.jsx
+++ b/starwarswiki/src/views/searchBarView.jsx
@@ -4,6 +4,7 @@ export default function SearchBarView(props) {
 	return (
 		<form onSubmit={props.handleFormSubmit}>
 			<ReactSearchAutocomplete
+				inputSearchString={props.searchString}
 				items={props.items}
 				onSelect={props.handleSearchSelect}
 				onSearch={props.handleOnSearch}


### PR DESCRIPTION
### Tasks complete
- Update text when no search results (Added  "Try again by typing in the search box")
- Clear the search box after a search to not confuse the user that they can search again
- Exit search box after search (On mobile the keyboard collapses)

### Testing
- Free text search (Typing for example "Skywalker" and pressing enter)
- Select an option by mouse click (Type "Skywal" and click! on Luke Skywalker)
- Select an option by pressing enter (Type "Skywal" and use arrow keys and press enter on Luke Skywalker)

### A little flicker
During the third test, you will notice the search options appearing again quickly before disappearing. This is due to my hacky fix of free search and I do not know how to fix it right now.