### PR TITLE
Add embla carousel at landing page

### DIFF
--- a/starwarswiki/package.json
+++ b/starwarswiki/package.json
@@ -12,6 +12,7 @@
 		"animejs": "^3.2.2",
 		"axios": "^1.6.2",
 		"dotenv": "^16.3.1",
+		"embla-carousel-autoplay": "^8.0.0-rc15",
 		"embla-carousel-react": "^8.0.0-rc15",
 		"firebase": "^10.7.1",
 		"firebase-tools": "^12.9.1",

--- a/starwarswiki/package.json
+++ b/starwarswiki/package.json
@@ -12,6 +12,7 @@
 		"animejs": "^3.2.2",
 		"axios": "^1.6.2",
 		"dotenv": "^16.3.1",
+		"embla-carousel-react": "^8.0.0-rc15",
 		"firebase": "^10.7.1",
 		"firebase-tools": "^12.9.1",
 		"framer-motion": "^10.16.16",

--- a/starwarswiki/src/components/EmblaCarousel.jsx
+++ b/starwarswiki/src/components/EmblaCarousel.jsx
@@ -2,6 +2,8 @@ import React, { useCallback } from 'react';
 import useEmblaCarousel from 'embla-carousel-react';
 import Autoplay from 'embla-carousel-autoplay';
 import Vortex from './Vortex';
+import LandingCard from './LandingCard';
+
 import '../style/embla.scss';
 
 export function EmblaCarousel(props) {
@@ -25,8 +27,13 @@ export function EmblaCarousel(props) {
 			<div className='embla-container'>
 				{props.data.map((item) => (
 					<div className='embla-slide' key={item.name}>
-						<p>{item.name}</p>
-						<img src={item.image} />
+						<LandingCard
+							text={item.name}
+							image={item.image}
+							altText={item.name}
+							linkTo={`${item.path}/${item.name.replaceAll('/', '%2F').replaceAll('.', '%2E')}`}
+							inAnimation={props.inAnimation}
+						/>
 					</div>
 				))}
 			</div>

--- a/starwarswiki/src/components/EmblaCarousel.jsx
+++ b/starwarswiki/src/components/EmblaCarousel.jsx
@@ -26,7 +26,7 @@ export function EmblaCarousel(props) {
 				{props.data.map((item) => (
 					<div className='embla__slide' key={item}>
 						<p>{item.name}</p>
-						<img src={item.image} width='200px' />
+						<img src={item.image} />
 					</div>
 				))}
 			</div>

--- a/starwarswiki/src/components/EmblaCarousel.jsx
+++ b/starwarswiki/src/components/EmblaCarousel.jsx
@@ -24,7 +24,7 @@ export function EmblaCarousel(props) {
 		<div className='embla' ref={emblaRef}>
 			<div className='embla__container'>
 				{props.data.map((item) => (
-					<div className='embla__slide' key={item}>
+					<div className='embla__slide' key={item.name}>
 						<p>{item.name}</p>
 						<img src={item.image} />
 					</div>

--- a/starwarswiki/src/components/EmblaCarousel.jsx
+++ b/starwarswiki/src/components/EmblaCarousel.jsx
@@ -1,9 +1,10 @@
 import React, { useCallback } from 'react';
 import useEmblaCarousel from 'embla-carousel-react';
 import Autoplay from 'embla-carousel-autoplay';
+import Vortex from './Vortex';
 import '../style/embla.scss';
 
-export const EmblaCarousel = () => {
+export function EmblaCarousel(props) {
 	const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true }, [Autoplay()]);
 
 	const scrollPrev = useCallback(() => {
@@ -14,12 +15,20 @@ export const EmblaCarousel = () => {
 		if (emblaApi) emblaApi.scrollNext();
 	}, [emblaApi]);
 
+	if (!props.dataLoaded) {
+		if (!props.loadingData) props.getData();
+		return <Vortex />;
+	}
+
 	return (
 		<div className='embla' ref={emblaRef}>
 			<div className='embla__container'>
-				<div className='embla__slide'>Slide 1</div>
-				<div className='embla__slide'>Slide 2</div>
-				<div className='embla__slide'>Slide 3</div>
+				{props.data.map((item) => (
+					<div className='embla__slide' key={item}>
+						<p>{item.name}</p>
+						<img src={item.image} width='200px' />
+					</div>
+				))}
 			</div>
 			<button className='embla__prev' onClick={scrollPrev}>
 				Prev
@@ -29,4 +38,4 @@ export const EmblaCarousel = () => {
 			</button>
 		</div>
 	);
-};
+}

--- a/starwarswiki/src/components/EmblaCarousel.jsx
+++ b/starwarswiki/src/components/EmblaCarousel.jsx
@@ -22,19 +22,23 @@ export function EmblaCarousel(props) {
 
 	return (
 		<div className='embla' ref={emblaRef}>
-			<div className='embla__container'>
+			<div className='embla-container'>
 				{props.data.map((item) => (
-					<div className='embla__slide' key={item.name}>
+					<div className='embla-slide' key={item.name}>
 						<p>{item.name}</p>
 						<img src={item.image} />
 					</div>
 				))}
 			</div>
-			<button className='embla__prev' onClick={scrollPrev}>
-				Prev
+			<button className='embla-prev' onClick={scrollPrev}>
+				<svg xmlns='http://www.w3.org/2000/svg' height='16' width='10' viewBox='0 0 320 512'>
+					<path d='M41.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 256 246.6 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z' />
+				</svg>
 			</button>
-			<button className='embla__next' onClick={scrollNext}>
-				Next
+			<button className='embla-next' onClick={scrollNext}>
+				<svg xmlns='http://www.w3.org/2000/svg' height='16' width='10' viewBox='0 0 320 512'>
+					<path d='M278.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-160 160c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L210.7 256 73.4 118.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l160 160z' />
+				</svg>
 			</button>
 		</div>
 	);

--- a/starwarswiki/src/components/EmblaCarousel.jsx
+++ b/starwarswiki/src/components/EmblaCarousel.jsx
@@ -1,0 +1,32 @@
+import React, { useCallback } from 'react';
+import useEmblaCarousel from 'embla-carousel-react';
+import Autoplay from 'embla-carousel-autoplay';
+import '../style/embla.scss';
+
+export const EmblaCarousel = () => {
+	const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true }, [Autoplay()]);
+
+	const scrollPrev = useCallback(() => {
+		if (emblaApi) emblaApi.scrollPrev();
+	}, [emblaApi]);
+
+	const scrollNext = useCallback(() => {
+		if (emblaApi) emblaApi.scrollNext();
+	}, [emblaApi]);
+
+	return (
+		<div className='embla' ref={emblaRef}>
+			<div className='embla__container'>
+				<div className='embla__slide'>Slide 1</div>
+				<div className='embla__slide'>Slide 2</div>
+				<div className='embla__slide'>Slide 3</div>
+			</div>
+			<button className='embla__prev' onClick={scrollPrev}>
+				Prev
+			</button>
+			<button className='embla__next' onClick={scrollNext}>
+				Next
+			</button>
+		</div>
+	);
+};

--- a/starwarswiki/src/components/EmblaCarousel.jsx
+++ b/starwarswiki/src/components/EmblaCarousel.jsx
@@ -30,7 +30,7 @@ export function EmblaCarousel(props) {
 						<LandingCard
 							text={item.name}
 							image={item.image}
-							altText={item.name}
+							altText=''
 							linkTo={`${item.path}/${item.name.replaceAll('/', '%2F').replaceAll('.', '%2E')}`}
 							inAnimation={props.inAnimation}
 						/>

--- a/starwarswiki/src/components/LandingCard.jsx
+++ b/starwarswiki/src/components/LandingCard.jsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 
 export default function LandingCard(props) {
 	return (
-		<div className='loading-card'>
+		<div>
 			<Link to={props.linkTo} replace={props.inAnimation ? true : false}>
 				<img src={props.image} alt={props.altText} />
 				<p>{props.text}</p>

--- a/starwarswiki/src/models/firebaseModel.js
+++ b/starwarswiki/src/models/firebaseModel.js
@@ -3,7 +3,7 @@ import { get, getDatabase, onValue, ref, remove, set } from 'firebase/database';
 import { getAuth, GoogleAuthProvider, onAuthStateChanged, signInWithPopup } from 'firebase/auth';
 import { queryClient, reactiveModel } from '../main';
 import { reaction } from 'mobx';
-import { fetchSWDatabank } from "../fetch.js";
+import { fetchSWDatabank } from '../fetch.js';
 
 const app = initializeApp({
 	apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -37,10 +37,10 @@ onAuthStateChanged(auth, async (user) => {
 		// User is signed in
 		reactiveModel.setUser(auth.currentUser);
 		readFromDB(user.uid);
-		readFriendsDB(user.uid)
+		readFriendsDB(user.uid);
 		await findUser(user.uid);
 		if (reactiveModel.isUser !== auth.currentUser.displayName) {
-			set(ref(db, '/users/' + user.uid), auth.currentUser.displayName)
+			set(ref(db, '/users/' + user.uid), auth.currentUser.displayName);
 		}
 	} else {
 		// No user is signed in
@@ -50,7 +50,7 @@ onAuthStateChanged(auth, async (user) => {
 
 export function persistence(model) {
 	reaction(listenACB, changeACB);
-	reaction(friends, updateFriends)
+	reaction(friends, updateFriends);
 
 	function listenACB() {
 		return [model.favorites];
@@ -61,12 +61,12 @@ export function persistence(model) {
 	}
 
 	function friends() {
-		return [reactiveModel.friends, reactiveModel.friendRequests, reactiveModel.sentRequests]
+		return [reactiveModel.friends, reactiveModel.friendRequests, reactiveModel.sentRequests];
 	}
 
 	function updateFriends() {
-		writeFriendsToDB()
-		reactiveModel.friends.map(readFriendFavFromDB)
+		writeFriendsToDB();
+		reactiveModel.friends.map(readFriendFavFromDB);
 	}
 }
 
@@ -107,33 +107,32 @@ export function readFriendFavFromDB(uid) {
 
 function readFriendsDB(uid) {
 	onValue(ref(db, '/friends/' + uid + '/addedFriends/'), (snapshot) => {
-		model.ready = false
+		model.ready = false;
 		const friendsFromDB = snapshot.val();
 		reactiveModel.setFriends(friendsFromDB);
 		if (friendsFromDB && Object.keys(friendsFromDB).length !== 0) {
-
-			reactiveModel.friends.map(findUser)
+			reactiveModel.friends.map(findUser);
 		}
 		model.wrote = false;
 		reactiveModel.loadingFriendsFav = false;
 		model.ready = true;
 	});
 	onValue(ref(db, '/friends/' + uid + '/pendingFriends'), (snapshot) => {
-		model.ready = false
+		model.ready = false;
 		const friendRequestsFromDB = snapshot.val();
-		reactiveModel.setFriendRequests(friendRequestsFromDB)
+		reactiveModel.setFriendRequests(friendRequestsFromDB);
 		if (friendRequestsFromDB && Object.keys(friendRequestsFromDB).length !== 0) {
-			reactiveModel.friendRequests.map(findUser)
+			reactiveModel.friendRequests.map(findUser);
 		}
 		model.wrote = false;
 		model.ready = true;
 	});
 	onValue(ref(db, '/friends/' + uid + '/requests'), (snapshot) => {
-		model.ready = false
+		model.ready = false;
 		const requestsFromDB = snapshot.val();
-		reactiveModel.setRequestsFromDb(requestsFromDB)
+		reactiveModel.setRequestsFromDb(requestsFromDB);
 		if (requestsFromDB && Object.keys(requestsFromDB).length !== 0) {
-			reactiveModel.sentRequests.map(findUser)
+			reactiveModel.sentRequests.map(findUser);
 		}
 		model.wrote = false;
 		model.ready = true;
@@ -142,103 +141,92 @@ function readFriendsDB(uid) {
 }
 
 function parseFriends(friends) {
-	if (!friends)
-		return ""
-	else
-		return friends
+	if (!friends) return '';
+	else return friends;
 }
 
 function writeFriendsToDB() {
 	if (model.user && model.ready) {
 		model.ready = false;
 		model.wrote = true;
-		if (reactiveModel.friends.length)
-			reactiveModel.friends.map(writeAddedFriends)
-		else
-			writeAddedFriends("")
-		if (reactiveModel.friendRequests.length)
-			reactiveModel.friendRequests.map(writePendingFriends)
-		else
-			writePendingFriends("")
-		if (reactiveModel.sentRequests.length)
-			reactiveModel.sentRequests.map(writeFriendRequests)
-		else
-			writeFriendRequests("")
+		if (reactiveModel.friends.length) reactiveModel.friends.map(writeAddedFriends);
+		else writeAddedFriends('');
+		if (reactiveModel.friendRequests.length) reactiveModel.friendRequests.map(writePendingFriends);
+		else writePendingFriends('');
+		if (reactiveModel.sentRequests.length) reactiveModel.sentRequests.map(writeFriendRequests);
+		else writeFriendRequests('');
 		model.ready = true;
 	}
 }
 
 function writeAddedFriends(friend) {
-	set(ref(db, '/friends/' + reactiveModel.user.uid + '/addedFriends/' + friend), true)
+	set(ref(db, '/friends/' + reactiveModel.user.uid + '/addedFriends/' + friend), true);
 }
 
 function writePendingFriends(friend) {
-	set(ref(db, '/friends/' + reactiveModel.user.uid + '/pendingFriends/' + friend), true)
+	set(ref(db, '/friends/' + reactiveModel.user.uid + '/pendingFriends/' + friend), true);
 }
 
 function writeFriendRequests(friend) {
-
-	set(ref(db, '/friends/' + reactiveModel.user.uid + '/requests/' + friend), true)
+	set(ref(db, '/friends/' + reactiveModel.user.uid + '/requests/' + friend), true);
 }
 
-
 export function addFriendDB(uid) {
-	set(ref(db, '/friends/' + uid + '/addedFriends/' + reactiveModel.user.uid), true)
+	set(ref(db, '/friends/' + uid + '/addedFriends/' + reactiveModel.user.uid), true);
 }
 
 export function removeFriendDB(uid) {
-	remove(ref(db, '/friends/' + uid + '/addedFriends/' + reactiveModel.user.uid))
+	remove(ref(db, '/friends/' + uid + '/addedFriends/' + reactiveModel.user.uid));
 }
 
 export async function findUser(uid) {
 	reactiveModel.gettingUser = true;
 	await get(ref(db, '/users/' + uid)).then((snapshot) => {
-		reactiveModel.setIsUser(snapshot.val())
-		reactiveModel.addUser(uid, snapshot.val())
-	})
+		reactiveModel.setIsUser(snapshot.val());
+		reactiveModel.addUser(uid, snapshot.val());
+	});
 }
 
 export function friendRequest(uid) {
-	set(ref(db, '/friends/' + uid + '/pendingFriends/' + reactiveModel.user.uid), true)
+	set(ref(db, '/friends/' + uid + '/pendingFriends/' + reactiveModel.user.uid), true);
 }
 
 export function removeFriendRequest(uid) {
-	remove(ref(db, '/friends/' + uid + '/pendingFriends/' + reactiveModel.user.uid))
+	remove(ref(db, '/friends/' + uid + '/pendingFriends/' + reactiveModel.user.uid));
 }
 
 export function removeRequest(uid) {
-	remove(ref(db, '/friends/' + uid + '/requests/' + reactiveModel.user.uid))
+	remove(ref(db, '/friends/' + uid + '/requests/' + reactiveModel.user.uid));
 }
 
 export async function getPreview() {
 	await get(ref(db, '/apiHash/')).then(async (snapshot) => {
-			const chars = snapshot.val().characters
-			const vehicles = snapshot.val().vehicles
-			const locations = snapshot.val().locations
-			const data = [];
-			let index = 0;
-			console.log(chars, vehicles, locations)
-			for (let i = 0; i < 3; i++) {
-				let path = 'characters/' + Object.keys(chars)[Math.floor(Math.random() * 26)]
-				await fetchSWDatabank(path, {}, path)
-				data[index++] = queryClient.getQueryData(path)
-
-			}
-			for (let i = 0; i < 3; i++) {
-				let path = 'vehicles/' + Object.keys(vehicles)[Math.floor(Math.random() * 23)]
-				await fetchSWDatabank(path, {}, path)
-				data[index++] = queryClient.getQueryData(path)
-			}
-			for (let i = 0; i < 3; i++) {
-				let path = 'locations/' + Object.keys(locations)[Math.floor(Math.random() * 23)]
-				await fetchSWDatabank(path, {}, path)
-				data[index++] = queryClient.getQueryData(path)
-			}
-			reactiveModel.setSwiperImage(data);
+		const chars = snapshot.val().characters;
+		const vehicles = snapshot.val().vehicles;
+		const locations = snapshot.val().locations;
+		const data = [];
+		let index = 0;
+		for (let i = 0; i < 3; i++) {
+			let path = 'characters/' + Object.keys(chars)[Math.floor(Math.random() * 26)];
+			await fetchSWDatabank(path, {}, path);
+			const { name, image } = queryClient.getQueryData(path);
+			data[index++] = { name: name, image: image, path: 'characters' };
 		}
-	);
+		for (let i = 0; i < 3; i++) {
+			let path = 'vehicles/' + Object.keys(vehicles)[Math.floor(Math.random() * 23)];
+			await fetchSWDatabank(path, {}, path);
+			const { name, image } = queryClient.getQueryData(path);
+			data[index++] = { name: name, image: image, path: 'vehicles' };
+		}
+		for (let i = 0; i < 3; i++) {
+			let path = 'locations/' + Object.keys(locations)[Math.floor(Math.random() * 23)];
+			await fetchSWDatabank(path, {}, path);
+			const { name, image } = queryClient.getQueryData(path);
+			data[index++] = { name: name, image: image, path: 'locations' };
+		}
+		reactiveModel.setSwiperImage(data);
+	});
 }
-
 
 export function readHash(location) {
 	get(ref(db, '/apiHash/' + location)).then((snapshot) =>

--- a/starwarswiki/src/models/firebaseModel.js
+++ b/starwarswiki/src/models/firebaseModel.js
@@ -1,8 +1,9 @@
 import { initializeApp } from 'firebase/app';
 import { get, getDatabase, onValue, ref, remove, set } from 'firebase/database';
 import { getAuth, GoogleAuthProvider, onAuthStateChanged, signInWithPopup } from 'firebase/auth';
-import { reactiveModel } from '../main';
+import { queryClient, reactiveModel } from '../main';
 import { reaction } from 'mobx';
+import { fetchSWDatabank } from "../fetch.js";
 
 const app = initializeApp({
 	apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -208,6 +209,36 @@ export function removeFriendRequest(uid) {
 export function removeRequest(uid) {
 	remove(ref(db, '/friends/' + uid + '/requests/' + reactiveModel.user.uid))
 }
+
+export async function getPreview() {
+	await get(ref(db, '/apiHash/')).then(async (snapshot) => {
+			const chars = snapshot.val().characters
+			const vehicles = snapshot.val().vehicles
+			const locations = snapshot.val().locations
+			const data = [];
+			let index = 0;
+			console.log(chars, vehicles, locations)
+			for (let i = 0; i < 3; i++) {
+				let path = 'characters/' + Object.keys(chars)[Math.floor(Math.random() * 26)]
+				await fetchSWDatabank(path, {}, path)
+				data[index++] = queryClient.getQueryData(path)
+
+			}
+			for (let i = 0; i < 3; i++) {
+				let path = 'vehicles/' + Object.keys(vehicles)[Math.floor(Math.random() * 23)]
+				await fetchSWDatabank(path, {}, path)
+				data[index++] = queryClient.getQueryData(path)
+			}
+			for (let i = 0; i < 3; i++) {
+				let path = 'locations/' + Object.keys(locations)[Math.floor(Math.random() * 23)]
+				await fetchSWDatabank(path, {}, path)
+				data[index++] = queryClient.getQueryData(path)
+			}
+			reactiveModel.setSwiperImage(data);
+		}
+	);
+}
+
 
 export function readHash(location) {
 	get(ref(db, '/apiHash/' + location)).then((snapshot) =>

--- a/starwarswiki/src/models/firebaseModel.js
+++ b/starwarswiki/src/models/firebaseModel.js
@@ -224,7 +224,7 @@ export async function getPreview() {
 			const { name, image } = queryClient.getQueryData(path);
 			data[index++] = { name: name, image: image, path: 'locations' };
 		}
-		reactiveModel.setSwiperImage(data);
+		reactiveModel.setCarouselData(data);
 	});
 }
 

--- a/starwarswiki/src/models/firebaseModel.js
+++ b/starwarswiki/src/models/firebaseModel.js
@@ -210,19 +210,34 @@ export async function getPreview() {
 			let path = 'characters/' + Object.keys(chars)[Math.floor(Math.random() * 26)];
 			await fetchSWDatabank(path, {}, path);
 			const { name, image } = queryClient.getQueryData(path);
-			data[index++] = { name: name, image: image, path: 'characters' };
+			if (data.some((item) => item.name === name)) {
+				i--;
+				continue;
+			} else {
+				data[index++] = { name: name, image: image, path: 'characters' };
+			}
 		}
 		for (let i = 0; i < 3; i++) {
 			let path = 'vehicles/' + Object.keys(vehicles)[Math.floor(Math.random() * 23)];
 			await fetchSWDatabank(path, {}, path);
 			const { name, image } = queryClient.getQueryData(path);
-			data[index++] = { name: name, image: image, path: 'vehicles' };
+			if (data.some((item) => item.name === name)) {
+				i--;
+				continue;
+			} else {
+				data[index++] = { name: name, image: image, path: 'vehicles' };
+			}
 		}
 		for (let i = 0; i < 3; i++) {
 			let path = 'locations/' + Object.keys(locations)[Math.floor(Math.random() * 23)];
 			await fetchSWDatabank(path, {}, path);
 			const { name, image } = queryClient.getQueryData(path);
-			data[index++] = { name: name, image: image, path: 'locations' };
+			if (data.some((item) => item.name === name)) {
+				i--;
+				continue;
+			} else {
+				data[index++] = { name: name, image: image, path: 'locations' };
+			}
 		}
 		reactiveModel.setCarouselData(data);
 	});

--- a/starwarswiki/src/models/model.js
+++ b/starwarswiki/src/models/model.js
@@ -17,6 +17,7 @@ export default {
 	moreDetails: {},
 	currentHash: undefined,
 	hash: {},
+	swiperImages: {},
 
 	searchResults: [],
 	searchString: undefined,
@@ -45,6 +46,10 @@ export default {
 
 	setInAnimation(boolean) {
 		this.inAnimation = boolean;
+	},
+
+	setSwiperImage(images) {
+		this.swiperImages = images;
 	},
 
 	setAutoCompleteResults(results) {

--- a/starwarswiki/src/models/model.js
+++ b/starwarswiki/src/models/model.js
@@ -17,7 +17,10 @@ export default {
 	moreDetails: {},
 	currentHash: undefined,
 	hash: {},
-	swiperImages: {},
+
+	carouselLoading: false,
+	carouselDataLoaded: undefined,
+	carouselData: [],
 
 	searchResults: [],
 	searchString: undefined,
@@ -48,8 +51,13 @@ export default {
 		this.inAnimation = boolean;
 	},
 
-	setSwiperImage(images) {
-		this.swiperImages = images;
+	setCarouselData(data) {
+		this.carouselData = data;
+		this.carouselDataLoaded = true;
+	},
+
+	setCarouselLoading(boolean) {
+		this.carouselLoading = boolean;
 	},
 
 	setAutoCompleteResults(results) {

--- a/starwarswiki/src/presenters/landingPagePresenter.jsx
+++ b/starwarswiki/src/presenters/landingPagePresenter.jsx
@@ -1,5 +1,7 @@
 import LandingPageView from '../views/landingPageView';
 import { observer } from 'mobx-react-lite';
+import { EmblaCarousel } from '../components/EmblaCarousel';
+import { getPreview } from '../models/firebaseModel';
 import { useEffect } from 'react';
 
 export default observer(function LandingPagePresenter(props) {
@@ -7,5 +9,30 @@ export default observer(function LandingPagePresenter(props) {
 		window.scrollTo(0, 0);
 	}, []);
 
-	return <LandingPageView inAnimation={props.model.inAnimation} />;
+	function getCarouselData() {
+		getPreview();
+		props.model.setCarouselLoading(true);
+	}
+
+	console.log('run');
+
+	const carouselData = Object.keys(props.model.carouselData).map((key) => {
+		return {
+			name: props.model.carouselData[key].name,
+			image: props.model.carouselData[key].image,
+			path: props.model.carouselData[key].path,
+		};
+	});
+
+	return (
+		<>
+			<LandingPageView inAnimation={props.model.inAnimation} />
+			<EmblaCarousel
+				data={carouselData}
+				loadingData={props.model.carouselLoading}
+				dataLoaded={props.model.carouselDataLoaded}
+				getData={getCarouselData}
+			/>
+		</>
+	);
 });

--- a/starwarswiki/src/presenters/landingPagePresenter.jsx
+++ b/starwarswiki/src/presenters/landingPagePresenter.jsx
@@ -23,14 +23,17 @@ export default observer(function LandingPagePresenter(props) {
 	});
 
 	return (
-		<>
+		<div className='landing-container'>
 			<LandingPageView inAnimation={props.model.inAnimation} />
-			<EmblaCarousel
-				data={carouselData}
-				loadingData={props.model.carouselLoading}
-				dataLoaded={props.model.carouselDataLoaded}
-				getData={getCarouselData}
-			/>
-		</>
+			<section>
+				<h2>Recomendations</h2>
+				<EmblaCarousel
+					data={carouselData}
+					loadingData={props.model.carouselLoading}
+					dataLoaded={props.model.carouselDataLoaded}
+					getData={getCarouselData}
+				/>
+			</section>
+		</div>
 	);
 });

--- a/starwarswiki/src/presenters/landingPagePresenter.jsx
+++ b/starwarswiki/src/presenters/landingPagePresenter.jsx
@@ -26,7 +26,7 @@ export default observer(function LandingPagePresenter(props) {
 		<div className='landing-container'>
 			<LandingPageView inAnimation={props.model.inAnimation} />
 			<section>
-				<h2>Recomendations</h2>
+				<h2>Recommendations</h2>
 				<EmblaCarousel
 					data={carouselData}
 					loadingData={props.model.carouselLoading}

--- a/starwarswiki/src/presenters/landingPagePresenter.jsx
+++ b/starwarswiki/src/presenters/landingPagePresenter.jsx
@@ -14,8 +14,6 @@ export default observer(function LandingPagePresenter(props) {
 		props.model.setCarouselLoading(true);
 	}
 
-	console.log('run');
-
 	const carouselData = Object.keys(props.model.carouselData).map((key) => {
 		return {
 			name: props.model.carouselData[key].name,

--- a/starwarswiki/src/style/embla.scss
+++ b/starwarswiki/src/style/embla.scss
@@ -1,0 +1,12 @@
+@import './variables.scss';
+
+.embla {
+	overflow: hidden;
+}
+.embla__container {
+	display: flex;
+}
+.embla__slide {
+	flex: 0 0 100%;
+	min-width: 0;
+}

--- a/starwarswiki/src/style/embla.scss
+++ b/starwarswiki/src/style/embla.scss
@@ -2,7 +2,8 @@
 
 .embla {
 	overflow: hidden;
-	-webkit-mask-image: linear-gradient(
+	width: 100vw;
+	mask-image: linear-gradient(
 		to right,
 		rgba(0, 0, 0, 0),
 		rgba(0, 0, 0, 1) 10%,
@@ -16,18 +17,24 @@
 	display: flex;
 	touch-action: pan-y;
 	height: 520px;
-	gap: $margin;
 }
 
 .embla__slide {
-	flex: 0 0 60%;
+	flex: 0 0 100%;
 	position: relative;
 	overflow: hidden;
+	margin-left: $margin;
 
 	img {
 		height: 100%;
 		width: 100%;
 		object-fit: cover;
 		object-position: center center;
+	}
+}
+
+@media only screen and (min-width: $big-screen) {
+	.embla__slide {
+		flex: 0 0 60%;
 	}
 }

--- a/starwarswiki/src/style/embla.scss
+++ b/starwarswiki/src/style/embla.scss
@@ -1,56 +1,33 @@
 @import './variables.scss';
 
 .embla {
-	--slide-spacing: $margin;
-	--slide-size: 60%;
-	--slide-height: auto;
 	overflow: hidden;
-	max-width: 100vw;
-	padding: 0;
+	-webkit-mask-image: linear-gradient(
+		to right,
+		rgba(0, 0, 0, 0),
+		rgba(0, 0, 0, 1) 10%,
+		rgba(0, 0, 0, 1) 90%,
+		rgba(0, 0, 0, 0) 100%
+	);
 }
+
 .embla__container {
 	backface-visibility: hidden;
 	display: flex;
 	touch-action: pan-y;
-	margin-left: calc(var(--slide-spacing) * -1);
+	height: 520px;
+	gap: $margin;
 }
+
 .embla__slide {
-	flex: 0 0 var(--slide-size);
-	min-width: 0;
-	padding-left: var(--slide-spacing);
+	flex: 0 0 60%;
 	position: relative;
-}
-.embla__slide__img {
-	display: block;
-	height: var(--slide-height);
-	width: 100%;
-	object-fit: cover;
-}
-.embla__slide__number {
-	width: 4.6rem;
-	height: 4.6rem;
-	z-index: 1;
-	position: absolute;
-	top: 0.6rem;
-	right: 0.6rem;
-	border-radius: 50%;
-	background-color: rgba(var(--background-site-rgb-value), 0.85);
-	line-height: 4.6rem;
-	font-weight: 900;
-	text-align: center;
-	pointer-events: none;
-}
-.embla__slide__number > span {
-	color: var(--brand-primary);
-	background-image: linear-gradient(45deg, var(--brand-primary), var(--brand-secondary));
-	background-clip: text;
-	-webkit-background-clip: text;
-	-webkit-text-fill-color: transparent;
-	font-size: 1.6rem;
-	display: block;
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
+	overflow: hidden;
+
+	img {
+		height: 100%;
+		width: 100%;
+		object-fit: cover;
+		object-position: center center;
+	}
 }

--- a/starwarswiki/src/style/embla.scss
+++ b/starwarswiki/src/style/embla.scss
@@ -2,7 +2,10 @@
 
 .embla {
 	overflow: hidden;
-	width: 100vw;
+	width: 100%;
+	padding-bottom: $margin;
+	position: relative;
+
 	mask-image: linear-gradient(
 		to right,
 		rgba(0, 0, 0, 0),
@@ -11,20 +14,17 @@
 		rgba(0, 0, 0, 0) 100%
 	);
 
-	position: relative;
-
 	.embla-container {
 		backface-visibility: hidden;
 		display: flex;
 		touch-action: pan-y;
-		height: 520px;
 	}
 
 	button {
 		background-color: transparent;
 		border: none;
 		position: absolute;
-		top: calc(50% - $margin);
+		top: calc(50% - 1.5 * $margin);
 
 		&.embla-prev {
 			left: 0px;
@@ -51,22 +51,41 @@
 }
 
 .embla-slide {
-	flex: 0 0 100%;
+	flex: 0 0 70%;
 	position: relative;
 	overflow: hidden;
 	margin-left: $margin;
+	border-radius: $corner-radius;
+	box-shadow: $yellow-glow;
 
-	img {
-		height: 100%;
-		width: 100%;
-		object-fit: cover;
-		object-position: center center;
+	> * {
+		a {
+			display: flex;
+			justify-content: center;
+			align-items: center;
+		}
+
+		p {
+			font-size: 1.5rem;
+			position: absolute;
+			color: $black;
+			text-shadow: $yellow-stroke-ie;
+			text-transform: capitalize;
+			text-align: center;
+		}
+
+		img {
+			width: 100%;
+			aspect-ratio: 16/9;
+			object-fit: cover;
+			filter: $black-overlay;
+		}
 	}
 }
 
 @media only screen and (min-width: $big-screen) {
 	.embla-slide {
-		flex: 0 0 60%;
+		flex: 0 0 25%;
 	}
 
 	.embla button {

--- a/starwarswiki/src/style/embla.scss
+++ b/starwarswiki/src/style/embla.scss
@@ -10,16 +10,47 @@
 		rgba(0, 0, 0, 1) 90%,
 		rgba(0, 0, 0, 0) 100%
 	);
+
+	position: relative;
+
+	.embla-container {
+		backface-visibility: hidden;
+		display: flex;
+		touch-action: pan-y;
+		height: 520px;
+	}
+
+	button {
+		background-color: transparent;
+		border: none;
+		position: absolute;
+		top: calc(50% - $margin);
+
+		&.embla-prev {
+			left: 0px;
+		}
+
+		&.embla-next {
+			right: 0px;
+		}
+
+		svg {
+			fill: $yellow;
+			height: calc(2 * $margin);
+			width: calc(2 * $margin);
+			stroke: black;
+			stroke-width: 8px;
+
+			transition: all 100ms ease-in-out;
+
+			&:hover {
+				transform: scale(0.9);
+			}
+		}
+	}
 }
 
-.embla__container {
-	backface-visibility: hidden;
-	display: flex;
-	touch-action: pan-y;
-	height: 520px;
-}
-
-.embla__slide {
+.embla-slide {
 	flex: 0 0 100%;
 	position: relative;
 	overflow: hidden;
@@ -34,7 +65,19 @@
 }
 
 @media only screen and (min-width: $big-screen) {
-	.embla__slide {
+	.embla-slide {
 		flex: 0 0 60%;
+	}
+
+	.embla button {
+		position: absolute;
+
+		&.embla-prev {
+			left: calc($margin * 4);
+		}
+
+		&.embla-next {
+			right: calc($margin * 4);
+		}
 	}
 }

--- a/starwarswiki/src/style/embla.scss
+++ b/starwarswiki/src/style/embla.scss
@@ -1,12 +1,56 @@
 @import './variables.scss';
 
 .embla {
+	--slide-spacing: $margin;
+	--slide-size: 60%;
+	--slide-height: auto;
 	overflow: hidden;
+	max-width: 100vw;
+	padding: 0;
 }
 .embla__container {
+	backface-visibility: hidden;
 	display: flex;
+	touch-action: pan-y;
+	margin-left: calc(var(--slide-spacing) * -1);
 }
 .embla__slide {
-	flex: 0 0 100%;
+	flex: 0 0 var(--slide-size);
 	min-width: 0;
+	padding-left: var(--slide-spacing);
+	position: relative;
+}
+.embla__slide__img {
+	display: block;
+	height: var(--slide-height);
+	width: 100%;
+	object-fit: cover;
+}
+.embla__slide__number {
+	width: 4.6rem;
+	height: 4.6rem;
+	z-index: 1;
+	position: absolute;
+	top: 0.6rem;
+	right: 0.6rem;
+	border-radius: 50%;
+	background-color: rgba(var(--background-site-rgb-value), 0.85);
+	line-height: 4.6rem;
+	font-weight: 900;
+	text-align: center;
+	pointer-events: none;
+}
+.embla__slide__number > span {
+	color: var(--brand-primary);
+	background-image: linear-gradient(45deg, var(--brand-primary), var(--brand-secondary));
+	background-clip: text;
+	-webkit-background-clip: text;
+	-webkit-text-fill-color: transparent;
+	font-size: 1.6rem;
+	display: block;
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
 }

--- a/starwarswiki/src/style/embla.scss
+++ b/starwarswiki/src/style/embla.scss
@@ -5,6 +5,7 @@
 	width: 100%;
 	padding-bottom: $margin;
 	position: relative;
+	text-align: center;
 
 	mask-image: linear-gradient(
 		to right,
@@ -58,6 +59,27 @@
 	border-radius: $corner-radius;
 	box-shadow: $yellow-glow;
 
+	background-image: repeating-linear-gradient(
+		0deg,
+		transparent,
+		transparent 5px,
+		rgba(77, 172, 220, 0.6) 10px,
+		rgba(77, 128, 230, 0.6) 15px
+	);
+
+	background-size: 100% 150%;
+	animation: hologram-animation 8s linear infinite;
+	transition: box-shadow 200ms ease-in-out;
+
+	&:hover {
+		box-shadow: $no-glow;
+	}
+
+	&:hover img {
+		filter: $no-overlay;
+		transform: scale(1.05) rotate(0);
+	}
+
 	> * {
 		a {
 			display: flex;
@@ -71,7 +93,6 @@
 			color: $black;
 			text-shadow: $yellow-stroke-ie;
 			text-transform: capitalize;
-			text-align: center;
 		}
 
 		img {
@@ -79,6 +100,9 @@
 			aspect-ratio: 16/9;
 			object-fit: cover;
 			filter: $black-overlay;
+
+			transition: all 200ms ease-in-out;
+			transform: scale(1.1) rotate(1deg);
 		}
 	}
 }

--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -185,7 +185,7 @@ main {
 .landing-page {
 	> * {
 		p {
-			font-size: 2.5rem;
+			font-size: 2rem;
 		}
 	}
 }
@@ -539,6 +539,7 @@ footer {
 	}
 
 	.landing-page {
+		flex-wrap: nowrap;
 		> * {
 			width: clamp(320px, 32%, 1200px);
 		}

--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -192,7 +192,6 @@ main {
 
 .main-title {
 	text-align: center;
-	margin-bottom: calc($margin / 2);
 
 	color: $black;
 	text-shadow: $yellow-stroke-ie;

--- a/starwarswiki/src/style/style.scss
+++ b/starwarswiki/src/style/style.scss
@@ -287,6 +287,17 @@ main {
 	}
 }
 
+.landing-container {
+	display: flex;
+	flex-direction: column;
+	gap: $margin;
+	text-align: center;
+
+	section h2 {
+		margin-bottom: calc($margin / 2);
+	}
+}
+
 .details-container {
 	background-color: $background-gray;
 	border-radius: $corner-radius;

--- a/starwarswiki/src/style/variables.scss
+++ b/starwarswiki/src/style/variables.scss
@@ -11,10 +11,9 @@ $no-glow: 0px 0px 0px 0px rgba(0, 0, 0, 0);
 $black-overlay: brightness(60%);
 $no-overlay: brightness(100%);
 
-$yellow-stroke-ie: -0.75px -0.75px 0 $yellow, 0.75px -0.75px 0 $yellow, -0.75px 0.75px 0 $yellow,
-	0.75px 0.75px 0 $yellow, -0.75px 0px 0 $yellow, 0.75px 0px 0 $yellow, 0px 0.75px 0 $yellow,
-	0px -0.75px 0 $yellow;
-$yellow-stroke: 0.75px $yellow;
+$yellow-stroke-ie: -1px -1px 0 $yellow, 1px -1px 0 $yellow, -1px 1px 0 $yellow, 1px 1px 0 $yellow,
+	-1px 0px 0 $yellow, 1px 0px 0 $yellow, 0px 1px 0 $yellow, 0px -1px 0 $yellow;
+$yellow-stroke: 1px $yellow;
 
 $corner-radius: 20px;
 

--- a/starwarswiki/yarn.lock
+++ b/starwarswiki/yarn.lock
@@ -2265,6 +2265,11 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
+embla-carousel-autoplay@^8.0.0-rc15:
+  version "8.0.0-rc15"
+  resolved "https://registry.yarnpkg.com/embla-carousel-autoplay/-/embla-carousel-autoplay-8.0.0-rc15.tgz#4d3c496dffc7cdc1230d487f1377dae80e56fa77"
+  integrity sha512-ABTbDJGNb9jzI9OV2vSpbUvxUA0ELmK0SI3yPm8Haj3ghssS+vElfahoDqp7zuFkWBRih6w3B51oMPKdF5J55A==
+
 embla-carousel-react@^8.0.0-rc15:
   version "8.0.0-rc15"
   resolved "https://registry.yarnpkg.com/embla-carousel-react/-/embla-carousel-react-8.0.0-rc15.tgz#1f5528256896f5b9a8a49c743d56a522519d47e7"

--- a/starwarswiki/yarn.lock
+++ b/starwarswiki/yarn.lock
@@ -2265,6 +2265,24 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
+embla-carousel-react@^8.0.0-rc15:
+  version "8.0.0-rc15"
+  resolved "https://registry.yarnpkg.com/embla-carousel-react/-/embla-carousel-react-8.0.0-rc15.tgz#1f5528256896f5b9a8a49c743d56a522519d47e7"
+  integrity sha512-PePOkyPMWsUDNJKYRhUmGScYhex9mfpEiYiKT8OgwP/4K60plW0qk8cAXWvS9N61A/3RkUq7uz+hQsmhAtYMcA==
+  dependencies:
+    embla-carousel "8.0.0-rc15"
+    embla-carousel-reactive-utils "8.0.0-rc15"
+
+embla-carousel-reactive-utils@8.0.0-rc15:
+  version "8.0.0-rc15"
+  resolved "https://registry.yarnpkg.com/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.0.0-rc15.tgz#29309e19657944bc3fb6a908a2da5675c7d2a325"
+  integrity sha512-17Pr+N2vULFS8Lxzi2jaebwVloiFJLpdJMJLKJKQ26NzEmX8pVtHSu3uuTWc8HPwye5HFugqCPJ2QoWWhKs6Kg==
+
+embla-carousel@8.0.0-rc15:
+  version "8.0.0-rc15"
+  resolved "https://registry.yarnpkg.com/embla-carousel/-/embla-carousel-8.0.0-rc15.tgz#68e269bb1ead1422aa3078401947f0d85c6e1671"
+  integrity sha512-s7VPexK2h8VEYjEVQFnJAPcRnY5YqJYicFxKVVyWXP3Hk9FFDkT0kqVxMM1PcL187qHOUgmGVHOrfC8xWy3OKQ==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"


### PR DESCRIPTION
### Changes
- Installed embla-carousel-autoplay & embla-carousel-react
- Add a carousel with recommended items 
- Download 3 random characters, 3 random vehicles and 3 random locations from the SWAPI hash on firebase. (So all of them will have more details when you click on them)

### How to test
- `yarn install`
- `yarn dev`
- Check if the carousel has a loading hologram effect
- Check that all items go to the correct page (especially Palpatine)
- Check if you can drag the carousel
- Check if you can use the buttons
- Check if it auto plays by default
- Check it on mobile as well